### PR TITLE
Add SSL on external image requests of items and outfits

### DIFF
--- a/config.php
+++ b/config.php
@@ -85,9 +85,9 @@ $config = array(
 	),
 
 	// images
-	'outfit_images_url' => 'http://outfit-images.ots.me/outfit.php', // set to animoutfit.php for animated outfit
+	'outfit_images_url' => 'https://outfit-images.ots.me/outfit.php', // set to animoutfit.php for animated outfit
 	'outfit_images_wrong_looktypes' => [75, 126, 127, 266, 302], // this looktypes needs to have different margin-top and margin-left because they are wrong positioned
-	'item_images_url' => 'http://item-images.ots.me/1092/', // set to images/items if you host your own items in images folder
+	'item_images_url' => 'https://item-images.ots.me/1092/', // set to images/items if you host your own items in images folder
 	'item_images_extension' => '.gif',
 
 	// account


### PR DESCRIPTION
This is a very simple pull request that suggests https rather than http, on external images requests specified at `config.php`.

## Why it's important:
Even one single resource loading from an insecure source, compromises the whole browser experience and affects how the website rank and look on Google.

### How some browsers behave when the website does have SSL certificate, but have insecure resources loading
---
![ssl-off](https://user-images.githubusercontent.com/1052507/103158327-4484f800-479b-11eb-8c14-446d5bcfc92f.png)

### How do they will behave with all resources being load through https
---
![ssl-on](https://user-images.githubusercontent.com/1052507/103158333-4fd82380-479b-11eb-94ba-5f7d3db40e5f.png)
