### PR TITLE
Fixes and improvements at template's network box

### DIFF
--- a/templates/tibiacom/boxes/networks.php
+++ b/templates/tibiacom/boxes/networks.php
@@ -1,5 +1,3 @@
 <?php
 
-$twig->display('networks.html.twig', array(
-	'topPlayers' => getTopPlayers(5)
-));
+$twig->display('networks.html.twig');

--- a/templates/tibiacom/boxes/templates/networks.html.twig
+++ b/templates/tibiacom/boxes/templates/networks.html.twig
@@ -1,22 +1,20 @@
+{% if config['network_facebook'] != '' or config['network_twitter'] != '' %}
 <div id="NetworksBox" class="Themebox" style="background-image:url({{ template_path }}/images/themeboxes/networks/networksbox.png);">
 	{% if config['network_facebook'] is not empty %}
 	<div id="FacebookBlock">
 		<div id="FacebookLikeBox">
 			<div class="fb-like-box fb_iframe_widget" data-href="https://www.facebook.com/{{ config['network_facebook'] }}" data-width="175" data-height="180" data-show-faces="true" data-stream="false" data-border-color="none" data-header="false" fb-xfbml-state="rendered">
-										<span style="vertical-align: bottom; width: 181px; height: 180px;">
-										</span>
+				<span style="vertical-align: bottom; width: 181px; height: 180px;"></span>
 			</div>
 		</div>
 		<div id="FacebookSendBox">
 			<div class="fb-send fb_iframe_widget" data-href="https://www.facebook.com/{{ config['network_facebook'] }}" data-width="50" data-height="20" fb-xfbml-state="rendered">
-										<span style="vertical-align: bottom; width: 50px; height: 20px;">
-										</span>
+				<span style="vertical-align: bottom; width: 50px; height: 20px;"></span>
 			</div>
 		</div>
 		<div id="FacebookLikes">
 			<div class="fb-like fb_edge_widget_with_comment fb_iframe_widget" data-href="https://www.facebook.com/{{ config['network_facebook'] }}" data-send="false" data-width="225" data-show-faces="false" fb-xfbml-state="rendered">
-										<span style="height: 28px; width: 225px;">
-										</span>
+				<span style="height: 28px; width: 225px;"></span>
 			</div>
 		</div>
 	</div>
@@ -29,3 +27,4 @@
 	{% endif %}
 	<div class="Bottom" style="background-image:url({{ template_path }}/images/general/box-bottom.gif);"></div>
 </div>
+{% endif %}

--- a/templates/tibiacom/index.php
+++ b/templates/tibiacom/index.php
@@ -12,9 +12,16 @@ if(isset($config['boxes']))
 	<link href="<?php echo $template_path; ?>/basic.css" rel="stylesheet" type="text/css" />
 	<script type="text/javascript" src="tools/basic.js"></script>
 	<script type="text/javascript" src="<?php echo $template_path; ?>/ticker.js"></script>
+	
+	<?php if(!empty($config['network_twitter'])): ?>
 	<script id="twitter-wjs" src="<?php echo $template_path; ?>/js/twitter.js"></script>
+	<?php endif; ?>
+
+	<?php if(!empty($config['network_facebook'])): ?>
 	<script id="facebook-jssdk" async src="<?php echo $template_path; ?>/js/facebook.js"></script>
 	<link href="<?php echo $template_path; ?>/css/facebook.css" rel="stylesheet" type="text/css">
+	<?php endif; ?>
+	
 	<script type="text/javascript">
 		var loginStatus="<?php echo ($logged ? 'true' : 'false'); ?>";
 		<?php


### PR DESCRIPTION
This pull request contains three commits about the template's network box.

## 1. Showing network box even without social networks specified
When you choose not set any social network at `config.ini`, the social box still shows up on the website.

![image](https://user-images.githubusercontent.com/1052507/103159626-689c0580-47aa-11eb-98d1-6f95bfdcbbad.png)

## 2. Unnecessary top players retrievement at network box
Seems there is a `getTopPlayers()` being called at `boxes/network.php` for no apparently reason.

## 3. Conditional script loading for social networks
To remove unnecessary script requests, if there isn't social networks set-up. 