### PR TITLE
Gratis premium account

### DIFF
--- a/system/libs/pot/OTS_Account.php
+++ b/system/libs/pot/OTS_Account.php
@@ -382,6 +382,10 @@ class OTS_Account extends OTS_Row_DAO implements IteratorAggregate, Countable
 		global $config;
 		if(isset($config['lua']['freePremium']) && getBoolean($config['lua']['freePremium'])) return -1;
 
+        if($this->data['premdays'] == 65535){
+            return 65535;
+        }
+        
 		$ret = ceil($this->data['premdays'] - (date("z", time()) + (365 * (date("Y", time()) - date("Y", $this->data['lastday']))) - date("z", $this->data['lastday'])));
 		return $ret > 0 ? $ret : 0;
 	}

--- a/system/pages/accountmanagement.php
+++ b/system/pages/accountmanagement.php
@@ -61,6 +61,7 @@ $errors = array();
 	if($action == '')
 	{
 		$freePremium = isset($config['lua']['freePremium']) && getBoolean($config['lua']['freePremium']) || $account_logged->getPremDays() == 65535;
+		$dayOrDays = $account_logged->getPremDays() == 1 ? 'day' : 'days';
 		/**
 		 * @var OTS_Account $account_logged
 		 */
@@ -68,7 +69,7 @@ $errors = array();
 		if(!$account_logged->isPremium())
 			$account_status = '<b><span style="color: red">Free Account</span></b>';
 		else
-			$account_status = '<b><span style="color: green">Premium Account, ' . ($freePremium ? 'Gratis Premium Account' : $account_logged->getPremDays() . ' days left') . '</span></b>';
+			$account_status = '<b><span style="color: green">Premium Account, ' . ($freePremium ? 'Gratis Premium Account' : $account_logged->getPremDays() . ' ' .$dayOrDays. ' left') . '</span></b>';
 
 		if(empty($recovery_key))
 			$account_registered = '<b><span style="color: red">No</span></b>';

--- a/system/pages/accountmanagement.php
+++ b/system/pages/accountmanagement.php
@@ -60,7 +60,7 @@ $errors = array();
 
 	if($action == '')
 	{
-		$freePremium = isset($config['lua']['freePremium']) && getBoolean($config['lua']['freePremium']);
+		$freePremium = isset($config['lua']['freePremium']) && getBoolean($config['lua']['freePremium']) || $account_logged->getPremDays() == 65535;
 		/**
 		 * @var OTS_Account $account_logged
 		 */
@@ -68,7 +68,7 @@ $errors = array();
 		if(!$account_logged->isPremium())
 			$account_status = '<b><span style="color: red">Free Account</span></b>';
 		else
-			$account_status = '<b><span style="color: green">Premium Account, ' . ($freePremium ? 'Unlimited' : $account_logged->getPremDays() . ' days left') . '</span></b>';
+			$account_status = '<b><span style="color: green">Premium Account, ' . ($freePremium ? 'Gratis Premium Account' : $account_logged->getPremDays() . ' days left') . '</span></b>';
 
 		if(empty($recovery_key))
 			$account_registered = '<b><span style="color: red">No</span></b>';

--- a/system/pages/admin/accounts.php
+++ b/system/pages/admin/accounts.php
@@ -182,7 +182,7 @@ if ($id > 0) {
 			}
 
 			$lastDay = 0;
-			if($p_days != 0 && $p_days != PHP_INT_MAX ) {
+			if($p_days != 0 && $p_days != 65535 ) {
 				$lastDay = time();
 			} else if ($lastDay != 0) {
 				$lastDay = 0;


### PR DESCRIPTION
At least in TFS 1.3 there's another condition of free premium account. When the server doesn't offer free premium and GMs/GODs have free premium in their entire account. That's defined in TFS by the account.premdays db field with 65535 value. The PHP_INT_MAX value doesn't work in that case because it assumes values of "2147483647" on 32bits and "9223372036854775807" on 64bits.

Also when GM/GOD log into their account tibia client shows "Gratis Premium Account" instead "unlimited".