### PR TITLE
refactor-account-type

### DIFF
--- a/config.php
+++ b/config.php
@@ -142,6 +142,15 @@ $config = array(
 		1 => 'Male'
 	),
 
+	// type of privilegies of the entire accounts - it's set in table accounts column type and defined in account.hpp AccountType
+	'account_types' => array(
+		1 => 'Player',
+		2 => 'Tutor',
+		3 => 'Senior Tutor',
+		4 => 'Gamemaster',
+		5 => 'God'
+	),
+
 	// new character config
 	'character_samples' => array( // vocations, format: ID_of_vocation => 'Name of Character to copy'
 		//0 => 'Rook Sample',

--- a/system/libs/CreateCharacter.php
+++ b/system/libs/CreateCharacter.php
@@ -81,6 +81,7 @@ class CreateCharacter
 	 * @param int $vocation
 	 * @param int $town
 	 * @param OTS_Account $account
+	 * @param int $groupId
 	 * @param array $errors
 	 * @return bool
 	 * @throws E_OTS_NotLoaded
@@ -88,7 +89,7 @@ class CreateCharacter
 	 * @throws Twig_Error_Runtime
 	 * @throws Twig_Error_Syntax
 	 */
-	public function doCreate($name, $sex, $vocation, $town, $account, &$errors)
+	public function doCreate($name, $sex, $vocation, $town, $account, $groupId, &$errors)
 	{
 		if(!$this->check($name, $sex, $vocation, $town, $errors)) {
 			return false;
@@ -179,6 +180,25 @@ class CreateCharacter
 			$player->setLossContainers($char_to_copy->getLossContainers());
 		}
 
+		/* Override settings when is a privileged player */
+		if($account->getType() >= 4 && $groupId != null){
+			$player->setGroupId($groupId); //set group id chosen
+			if ($groupId == 4) {
+				$name = "GM ".$name;
+				$player->setLookType(75);
+			}				
+			if ($groupId == 5){
+				$name = "CM ".$name;
+				$player->setLookType(302);
+			}				
+			if ($groupId == 6){
+				$player->setLookType(266);
+			}
+			$player->setName($name);
+		}			
+		if($account->getType() >=2 && $account->getType() <= 3)
+			$player->setGroupId($account->getType());
+		
 		$player->save();
 		$player->setCustomField('created', time());
 

--- a/system/libs/pot/OTS_Account.php
+++ b/system/libs/pot/OTS_Account.php
@@ -187,7 +187,7 @@ class OTS_Account extends OTS_Row_DAO implements IteratorAggregate, Countable
 		}
 
         // SELECT query on database
-		$this->data = $this->db->query('SELECT `id`, ' . ($this->db->hasColumn('accounts', 'name') ? '`name`,' : '') . '`password`, `email`, `blocked`, `rlname`, `location`, `country`, `web_flags`, ' . ($this->db->hasColumn('accounts', 'premdays') ? '`premdays`, ' : '') . ($this->db->hasColumn('accounts', 'lastday') ? '`lastday`, ' : ($this->db->hasColumn('accounts', 'premend') ? '`premend`,' : ($this->db->hasColumn('accounts', 'premium_ends_at') ? '`premium_ends_at`,' : ''))) . '`created` FROM `accounts` WHERE `id` = ' . (int) $id)->fetch();
+		$this->data = $this->db->query('SELECT `id`, ' . ($this->db->hasColumn('accounts', 'name') ? '`name`,' : '') . '`password`, `email`, `blocked`, `rlname`, `location`, `country`, `web_flags`, ' . ($this->db->hasColumn('accounts', 'premdays') ? '`premdays`, ' : '') . ($this->db->hasColumn('accounts', 'lastday') ? '`lastday`, ' : ($this->db->hasColumn('accounts', 'premend') ? '`premend`,' : ($this->db->hasColumn('accounts', 'premium_ends_at') ? '`premium_ends_at`,' : ''))) . '`created`'. ($this->db->hasColumn('accounts', 'type') ? ', `type`' : '') .' FROM `accounts` WHERE `id` = ' . (int) $id)->fetch();
 		self::$cache[$id] = $this->data;
     }
 
@@ -426,6 +426,47 @@ class OTS_Account extends OTS_Row_DAO implements IteratorAggregate, Countable
         }
 
         return $this->data['created'];
+    }
+
+    public function getType()
+    {
+        if( !isset($this->data['type']) )
+        {
+            throw new E_OTS_NotLoaded();
+        }
+
+        return $this->data['type'];
+    }
+
+    public function getAllowedCharactersGroupIds()
+    {
+        $groupsToShow = array();
+        if( !isset($this->data['type']) )
+        {
+            return $groupsToShow;
+        }
+
+		if( $this->data['type'] > 3){  //if is a gm or above access allow him/her to choose what type of player will create
+
+			$groups = new OTS_Groups_List();
+		
+			foreach($groups as $group){
+				$id = $group->getId();
+				$name = $group->getName();	
+				if( $this->data['type'] == 4){
+					if($id == 1 || $id == 4){ //if is gm - allow create gms and normal player only
+						array_push($groupsToShow, array(
+							$id => $name
+						));
+					}					
+				} else { //if cm/god allow create all group ids
+					array_push($groupsToShow, array(
+						$id => $name
+					));
+				}
+			}
+		}
+        return $groupsToShow;
     }
 
 /**

--- a/system/libs/pot/OTS_Groups_List.php
+++ b/system/libs/pot/OTS_Groups_List.php
@@ -37,8 +37,8 @@ class OTS_Groups_List implements IteratorAggregate, Countable
 			{
 				$info = array();
 				$info['id'] = $group['id'];
-				$info['name'] = $group['name'];
-				$info['access'] = $group['name'];
+				$info['name'] = ucwords($group['name']);
+				$info['access'] = $group['access'];
 				$this->groups[$group['id']] = new OTS_Group($info);
 			}
 			
@@ -79,7 +79,7 @@ class OTS_Groups_List implements IteratorAggregate, Countable
 				{
 					$data[$group->getAttribute('id')] = array(
 						'id' => $group->getAttribute('id'),
-						'name' => $group->getAttribute('name'),
+						'name' => ucwords($group->getAttribute('name')),
 						'access' => $group->getAttribute('access')
 					);
 				}
@@ -105,7 +105,7 @@ class OTS_Groups_List implements IteratorAggregate, Countable
 			{
 				$data[$group->getAttribute('id')] = array(
 					'id' => $group->getAttribute('id'),
-					'name' => $group->getAttribute('name'),
+					'name' => ucwords($group->getAttribute('name')),
 					'access' => $group->getAttribute('access')
 				);
 

--- a/system/libs/validator.php
+++ b/system/libs/validator.php
@@ -288,6 +288,18 @@ class Validator
 			return false;
 		}
 
+		$player->find("CM ".$name);
+		if($player->isLoaded()) {
+			self::$lastError = 'Community manager character with this name already exist.';
+			return false;
+		}
+
+		$player->find("GM ".$name);
+		if($player->isLoaded()) {
+			self::$lastError = 'Gamemaster character with this name already exist.';
+			return false;
+		}
+
 		//check if was namelocked previously
 		if($db->hasTable('player_namelocks') && $db->hasColumn('player_namelocks', 'name')) {
 			$namelock = $db->query('SELECT `player_id` FROM `player_namelocks` WHERE `name` = ' . $db->quote($name));

--- a/system/pages/account/create_character.php
+++ b/system/pages/account/create_character.php
@@ -14,6 +14,7 @@ $character_name = isset($_POST['name']) ? stripslashes(ucwords(strtolower($_POST
 $character_sex = isset($_POST['sex']) ? (int)$_POST['sex'] : null;
 $character_vocation = isset($_POST['vocation']) ? (int)$_POST['vocation'] : null;
 $character_town = isset($_POST['town']) ? (int)$_POST['town'] : null;
+$character_groupId = isset($_POST['type']) ? (int)$_POST['type'] : null;
 
 $character_created = false;
 $save = isset($_POST['save']) && $_POST['save'] == 1;
@@ -22,7 +23,7 @@ if($save) {
 	require_once LIBS . 'CreateCharacter.php';
 	$createCharacter = new CreateCharacter();
 
-	$character_created = $createCharacter->doCreate($character_name, $character_sex, $character_vocation, $character_town, $account_logged, $errors);
+	$character_created = $createCharacter->doCreate($character_name, $character_sex, $character_vocation, $character_town, $account_logged, $character_groupId, $errors);
 }
 
 if(count($errors) > 0) {

--- a/system/pages/characters.php
+++ b/system/pages/characters.php
@@ -23,6 +23,16 @@ function generate_search_form($autofocus = false)
 	));
 }
 
+function retrieve_account_type($accountType)
+{
+       global $config;
+       if ( !array_key_exists($accountType, $config['account_types'])){
+               return "Invalid account type";
+       } else {
+               return $config['account_types'][$accountType];
+       }
+}
+
 function retrieve_former_name($name)
 {
 	global $oldName, $db;
@@ -416,7 +426,8 @@ WHERE killers.death_id = '".$death['id']."' ORDER BY killers.final_hit DESC, kil
 		'characters_link' => getLink('characters'),
 		'account_players' => isset($account_players) ? $account_players : null,
 		'search_form' => generate_search_form(),
-		'canEdit' => hasFlag(FLAG_CONTENT_PLAYERS) || superAdmin()
+		'canEdit' => hasFlag(FLAG_CONTENT_PLAYERS) || superAdmin(),
+		'accountType' => retrieve_account_type($account->getType())
 	));
 }
 else

--- a/system/pages/createaccount.php
+++ b/system/pages/createaccount.php
@@ -268,7 +268,7 @@ if($save)
 
 			if(config('account_create_character_create')) {
 				// character creation
-				$character_created = $createCharacter->doCreate($character_name, $character_sex, $character_vocation, $character_town, $new_account, $errors);
+				$character_created = $createCharacter->doCreate($character_name, $character_sex, $character_vocation, $character_town, $new_account, 1, $errors);
 				if (!$character_created) {
 					error('There was an error creating your character. Please create your character later in account management page.');
 				}

--- a/system/templates/account.create_character.html.twig
+++ b/system/templates/account.create_character.html.twig
@@ -2,6 +2,13 @@ Please choose a name{% if config.character_samples|length > 1 %}, vocation{% end
 {% if config.character_towns|length > 1 %}, town{% endif %}
  and sex for your character. <br/>
 In any case the name must not violate the naming conventions stated in the <a href="?subtopic=rules" target="_blank" >{{ config.lua.serverName }} Rules</a>, or your character might get deleted or name locked.
+<br/>
+{% if account_logged.getType() == 4 %}
+	<b>The "GM" prefix will be automatically added if you choose "Gamemaster" privilege.</b><br/>
+{% elseif account_logged.getType() > 4 %}
+	<b>The "GM" prefix will be automatically added if you choose "Gamemaster" privilege.</b><br/>
+	<b>The "CM" prefix will be automatically added if you choose "Community Manager" privilege.</b><br/>
+{% endif %}
 {% if account_logged.getPlayersList()|length >= config.characters_per_account %}
 <b><span style="color: red"> You have maximum number of characters per account on your account. Delete one before you make new.</span></b>
 {% endif %}
@@ -42,6 +49,11 @@ In any case the name must not violate the naming conventions stated in the <a hr
 													<td>
 														<span>Sex</span>
 													</td>
+													{% if account_logged.getType() >= 4 %}
+													<td>
+														<span>Privilege</span>
+													</td>
+													{% endif %}
 												</tr>
 												<tr class="Odd">
 													<td>
@@ -60,6 +72,19 @@ In any case the name must not violate the naming conventions stated in the <a hr
 														><label for="sex{{ i }}">{{ gender|lower }}</label><br/>
 														{% endfor %}
 													</td>
+													{% if account_logged.getType() >= 4 %}
+														<td>
+															{% set i = 1 %}
+															{% set groups = account_logged.getAllowedCharactersGroupIds() %}
+															{% for group in groups %}
+																{% for id, type in group %}																	
+																	<input type="radio" name="type" id="type{{ i }}" value="{{ id }}"{% if i == 1 %} checked="checked"{% endif %}
+																	><label for="type{{ i }}">{{ type }}</label><br/>
+																{% endfor %}
+																{% set i = i + 1 %}
+															{% endfor %}
+														</td>
+													{% endif %}
 												</tr>
 											</table>
 										</div>

--- a/system/templates/characters.html.twig
+++ b/system/templates/characters.html.twig
@@ -130,6 +130,15 @@
 				<td>{% if player.getLastLogin() == 0 %}Never logged in.{% else %}{{ player.getLastLogin()|date("M d Y, H:i:s") }} CEST{% endif %}</td>
 			</tr>
 
+			{% set group = player.getGroup() %}
+			{% if group.isLoaded() and group.getId() > 3 %}
+			{% set rows = rows + 1 %}
+			<tr bgcolor="{{ getStyle(rows) }}">
+				<td>Position:</td>
+				<td>{{ group.getName() }}</td>
+			</tr>
+			{% endif %}
+
 			{% if config.characters.creation_date %}
 			{% set rows = rows + 1 %}
 			<tr bgcolor="{{ getStyle(rows) }}">
@@ -335,15 +344,6 @@
 			</tr>
 			{% endif %}
 
-			{% set group = player.getGroup() %}
-			{% if group.isLoaded() and group.getId() != 1 %}
-			{% set rows = rows + 1 %}
-			<tr bgcolor="{{ getStyle(rows) }}">
-				<td>Position:</td>
-				<td>{{ group.getName()|capitalize }}</td>
-			</tr>
-			{% endif %}
-
 			{% set realLocation = account.getLocation() %}
 			{% if realLocation is not empty %}
 			{% set rows = rows + 1 %}
@@ -352,7 +352,15 @@
 				<td>{{ realLocation }}</td>
 			</tr>
 			{% endif %}
-
+			
+			{% if accountType != "Player" %}
+			{% set rows = rows + 1 %}
+			<tr bgcolor="{{ getStyle(rows) }}">
+				<td>Position:</td>
+				<td>{{ accountType }}</td>
+			</tr>
+			{% endif %}
+			
 			{% set rows = rows + 1 %}
 			<tr bgcolor="{{ getStyle(rows) }}">
 				<td width="20%">Created:</td>


### PR DESCRIPTION
* show both player.groupid and account.type like global (https://www.tibia.com/community/?subtopic=characters&name=Xolurr)
* set Upper Case on the first letter of each word in the player group name when backend loads it instead twig template

* add feature of creating a privilege player based on account type
 - tutor and senior tutor account new characters get automatically the respective player.group.id
 - when GM account create new character enable option to chose new character privilege between "normal player" or "GM" (GM prefix in the name is added by the backend and validated avoiding duplication exception)
 - when GOD account create new character enable option to chose new character privilege between "normal player", "tutor", "senior tutor", "GM", "CM" or "GOD" (GM and CM prefix in the name are added by the backend and validated avoiding duplication exception)