### PR TITLE
Fix: admin page changed feet to match body colour

### DIFF
--- a/admin/pages/players.php
+++ b/admin/pages/players.php
@@ -650,7 +650,7 @@ else if ($id > 0 && isset($player) && $player->isLoaded())
 											<label for="look_feet" class="control-label">Feet: <span
 														id="look_feet_val"></span></label>
 											<input type="range" min="0" max="132"
-												   value="<?php echo $player->getLookBody(); ?>"
+												   value="<?php echo $player->getLookFeet(); ?>"
 												   class="slider form-control" id="look_feet" name="look_feet">
 										</div>
 									</div>


### PR DESCRIPTION
Fixes #173

Fix: admin page changed feet to match body colour

When saving changes to a character, the admin page overwrote their foot colour with the body colour.
This fix renders the correct variable into the page so the foot colour is preserved.