### PR TITLE
Fix rules page formatting

### DIFF
--- a/system/templates/rules.html.twig
+++ b/system/templates/rules.html.twig
@@ -1,8 +1,2 @@
-{% if constant('PAGE') == 'rules' %}
 <b>{{ config.lua.serverName }} Rules</b><br/>
-<textarea rows="25" wrap="physical" cols="70" readonly="true">
-{% endif %}
-{{ getCustomPage('rules_on_the_page') }}
-{% if constant('PAGE') == 'rules' %}
-	</textarea>
-{% endif %}
+{{ getCustomPage('rules_on_the_page') | nl2br }}


### PR DESCRIPTION
Fixes #176

Remove `textarea` from rules page and use Twig's nl2br function to format the text.
