### PR TITLE
Bugfix: database and finish step errors

### DIFF
--- a/install/tools/5-database.php
+++ b/install/tools/5-database.php
@@ -11,8 +11,10 @@ $error = false;
 require BASE . 'install/includes/config.php';
 
 ini_set('max_execution_time', 300);
-ob_implicit_flush();
-ob_end_flush();
+if(ob_get_length() > 0) {
+	ob_implicit_flush();
+	ob_end_flush();
+}
 header('X-Accel-Buffering: no');
 
 if(!$error) {

--- a/install/tools/7-finish.php
+++ b/install/tools/7-finish.php
@@ -8,8 +8,10 @@ require BASE . 'install/includes/functions.php';
 require BASE . 'install/includes/locale.php';
 
 ini_set('max_execution_time', 300);
-ob_implicit_flush();
-ob_end_flush();
+if(ob_get_length() > 0) {
+	ob_implicit_flush();
+	ob_end_flush();
+}
 header('X-Accel-Buffering: no');
 
 if(isset($config['installed']) && $config['installed'] && !isset($_SESSION['saved'])) {


### PR DESCRIPTION
I was trying to run thw website locally (PHP 8) and I found that both database and finish steps were not running successfully:

![image](https://github.com/slawkens/myaac/assets/9318356/1c82e7de-8071-44e8-aae2-c1005dd4339e)

When this happens on Database step and by hitting Next button at this step, the Finish step were skipped. It was assuming that it was already installed on ```if(isset($config['installed']) && $config['installed'] && !isset($_SESSION['saved'])) {```

By reading [ob_end_flush()](https://www.php.net/manual/en/function.ob-end-flush.php) docs, and by reading the Notice message, I found that it was throwning an error (which was unhandled at this time).

After applying these changes on Database step, the same error happened on Finish step

I simple added a check if the buffer has data to flush to avoid it. Maybe the best approach would be to catch the exception. But As it is part of install, which would be executed once, I think the if check is enough.

 I could not force a valid buffer to see if the end_flush would fail in the same way that it was before


