### PR TITLE
feat: new hook: HOOK_FILTER_POT, possibility to replace POT classes

### DIFF
--- a/system/libs/pot/OTS.php
+++ b/system/libs/pot/OTS.php
@@ -313,13 +313,15 @@ class POT
 	{
 		if( preg_match('/^(I|E_)?OTS_/', $class) > 0) {
 			global $hooks;
-
 			$include = $this->path . $class . '.php';
 
-			$args = ['include' => $include, 'class' => $class];
-			$hooks->triggerFilter(HOOK_FILTER_POT, $args);
+			if (isset($hooks)) {
+				$args = ['include' => $include, 'class' => $class];
+				$hooks->triggerFilter(HOOK_FILTER_POT, $args);
 
-			$include = $args['include'];
+				$include = $args['include'];
+			}
+
 			include_once($include);
 		}
 	}

--- a/system/libs/pot/OTS.php
+++ b/system/libs/pot/OTS.php
@@ -311,9 +311,16 @@ class POT
  */
 	public function loadClass($class)
 	{
-		if( preg_match('/^(I|E_)?OTS_/', $class) > 0)
-		{
-			include_once($this->path . $class . '.php');
+		if( preg_match('/^(I|E_)?OTS_/', $class) > 0) {
+			global $hooks;
+
+			$include = $this->path . $class . '.php';
+
+			$args = ['include' => $include, 'class' => $class];
+			$hooks->triggerFilter(HOOK_FILTER_POT, $args);
+
+			$include = $args['include'];
+			include_once($include);
 		}
 	}
 

--- a/system/src/global.php
+++ b/system/src/global.php
@@ -102,6 +102,7 @@ define('HOOK_FILTER_ROUTES', ++$i);
 define('HOOK_FILTER_TWIG_DISPLAY', ++$i);
 define('HOOK_FILTER_TWIG_RENDER', ++$i);
 define('HOOK_FILTER_THEME_FOOTER', ++$i);
+define('HOOK_FILTER_POT', ++$i);
 
 const HOOK_FIRST = HOOK_INIT;
 define('HOOK_LAST', $i);


### PR DESCRIPTION
This PR adds possibility to customize the POT classes, like OTS_Player etc.

Example hook:

<details>
<summary>plugin.json</summary>

```
"routes-example": {
	"type": "FILTER_POT",
	"file": "plugins/example-plugin/pot.php"
}
```
</details>
<details>
<summary>plugins/example-plugin/pot.php</summary>

```php
<?php

if ($args['class'] == 'OTS_Player') {
	$args['include'] = PLUGINS . 'example-plugin/pot/OTS_Player.php';
}
```
</details>