### PR TITLE
fix: boostedcreatures for 13.40

### DIFF
--- a/login.php
+++ b/login.php
@@ -88,8 +88,8 @@ switch ($action) {
 	case 'boostedcreature':
 		$clientVersion = (int)setting('core.client');
 
-		// 13.40 exclusively and 14.00+
-		if ($clientVersion == 1340 || $clientVersion >= 1400) {
+		// 13.40 and up
+		if ($clientVersion >= 1340) {
 			$creatureBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_creature'))->fetchAll();
 			$bossBoost     = $db->query("SELECT * FROM " . $db->tableName('boosted_boss'))->fetchAll();
 			die(json_encode([

--- a/login.php
+++ b/login.php
@@ -88,8 +88,8 @@ switch ($action) {
 	case 'boostedcreature':
 		$clientVersion = (int)setting('core.client');
 
-		// 14.00 and up
-		if ($clientVersion >= 1400) {
+		// 13.40 exclusively and 14.00+
+		if ($clientVersion == 1340 || $clientVersion >= 1400) {
 			$creatureBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_creature'))->fetchAll();
 			$bossBoost     = $db->query("SELECT * FROM " . $db->tableName('boosted_boss'))->fetchAll();
 			die(json_encode([


### PR DESCRIPTION
Fixes the boosted boss/creature display on the login page for 13.40 running the default cipsoft client.

Without this fix, 13.40 clients only have boosted creature, and not boss.