### PR TITLE
improve: add structured login errors, diagnostics & admin hints

### DIFF
--- a/login.php
+++ b/login.php
@@ -97,6 +97,37 @@ function parseEventSchedulerXmlValue($table, $attribute, $default = '')
 	return $value === 'error' ? $default : $value;
 }
 
+function createEventScheduleJsonEntry($event)
+{
+	if (!is_array($event)) {
+		return null;
+	}
+
+	$defaultHour = isset($event['hour']) ? (string)$event['hour'] : '';
+	$startHour = isset($event['starthour']) ? (string)$event['starthour'] : $defaultHour;
+	$endHour = isset($event['endhour']) ? (string)$event['endhour'] : $defaultHour;
+	$startDate = parseEventSchedulerJsonDate($event['startdate'] ?? '', $startHour);
+	$endDate = parseEventSchedulerJsonDate($event['enddate'] ?? '', $endHour, true);
+	if ($startDate === null || $endDate === null) {
+		return null;
+	}
+
+	$colors = isset($event['colors']) && is_array($event['colors']) ? $event['colors'] : [];
+	$details = isset($event['details']) && is_array($event['details']) ? $event['details'] : [];
+
+	return [
+		'colorlight' => (string)($colors['colorlight'] ?? ''),
+		'colordark' => (string)($colors['colordark'] ?? ''),
+		'description' => (string)($event['description'] ?? ''),
+		'displaypriority' => intval($details['displaypriority'] ?? 0),
+		'enddate' => intval($endDate),
+		'isseasonal' => getBoolean($details['isseasonal'] ?? false),
+		'name' => (string)($event['name'] ?? ''),
+		'startdate' => intval($startDate),
+		'specialevent' => intval($details['specialevent'] ?? 0)
+	];
+}
+
 function loadEventScheduleFromJson($filePath)
 {
 	if (!file_exists($filePath)) {
@@ -119,33 +150,12 @@ function loadEventScheduleFromJson($filePath)
 
 	$eventlist = [];
 	foreach ($json['events'] as $event) {
-		if (!is_array($event)) {
+		$eventEntry = createEventScheduleJsonEntry($event);
+		if ($eventEntry === null) {
 			continue;
 		}
 
-		$defaultHour = isset($event['hour']) ? (string)$event['hour'] : '';
-		$startHour = isset($event['starthour']) ? (string)$event['starthour'] : $defaultHour;
-		$endHour = isset($event['endhour']) ? (string)$event['endhour'] : $defaultHour;
-		$startDate = parseEventSchedulerJsonDate($event['startdate'] ?? '', $startHour);
-		$endDate = parseEventSchedulerJsonDate($event['enddate'] ?? '', $endHour, true);
-		if ($startDate === null || $endDate === null) {
-			continue;
-		}
-
-		$colors = isset($event['colors']) && is_array($event['colors']) ? $event['colors'] : [];
-		$details = isset($event['details']) && is_array($event['details']) ? $event['details'] : [];
-
-		$eventlist[] = [
-			'colorlight' => (string)($colors['colorlight'] ?? ''),
-			'colordark' => (string)($colors['colordark'] ?? ''),
-			'description' => (string)($event['description'] ?? ''),
-			'displaypriority' => intval($details['displaypriority'] ?? 0),
-			'enddate' => intval($endDate),
-			'isseasonal' => getBoolean($details['isseasonal'] ?? false),
-			'name' => (string)($event['name'] ?? ''),
-			'startdate' => intval($startDate),
-			'specialevent' => intval($details['specialevent'] ?? 0)
-		];
+		$eventlist[] = $eventEntry;
 	}
 
 	return $eventlist;

--- a/login.php
+++ b/login.php
@@ -12,19 +12,155 @@ require_once SYSTEM . 'functions.php';
 require_once SYSTEM . 'init.php';
 require_once SYSTEM . 'status.php';
 
+const LOGIN_ERROR_INVALID_CREDENTIALS = 3;
+const LOGIN_ERROR_TWO_FACTOR_REQUIRED = 6;
+const LOGIN_ERROR_DATABASE_UNAVAILABLE = 2001;
+const LOGIN_ERROR_ACCOUNT_DATA_UNAVAILABLE = 2002;
+const LOGIN_ERROR_CHARACTER_LIST_LOAD_FAILED = 2003;
+const LOGIN_ERROR_LOGIN_SERVICE_UNAVAILABLE = 3001;
+const LOGIN_ERROR_UNSUPPORTED_REQUEST_TYPE = 3002;
+const LOGIN_ERROR_MALFORMED_REQUEST = 3003;
+const LOGIN_ERROR_JSON_RESPONSE_FAILED = 3004;
+const LOGIN_ERROR_EVENT_SCHEDULE_UNAVAILABLE = 4001;
+const LOGIN_ERROR_BOOSTED_DATA_UNAVAILABLE = 4002;
+const LOGIN_ERROR_LIVESTREAM_UNAVAILABLE = 4003;
+const LOGIN_ERROR_LIVESTREAM_DATA_UNAVAILABLE = 4004;
+const LOGIN_ACCOUNT_TYPE_GAMEMASTER = 4;
+const LOGIN_ACCOUNT_GROUP_GAMEMASTER = 4;
+
 # error function
 function sendError($message, $code = 3){
-	$ret = [];
-	$ret['errorCode'] = $code;
-	$ret['errorMessage'] = $message;
-	die(json_encode($ret));
+	sendJsonResponse([
+		'errorCode' => $code,
+		'errorMessage' => $message
+	]);
+}
+
+function sendJsonResponse($data)
+{
+	if (!headers_sent()) {
+		header('Content-Type: application/json');
+		http_response_code(200);
+	}
+
+	$response = json_encode($data);
+	if ($response === false) {
+		$response = '{"errorCode":' . LOGIN_ERROR_JSON_RESPONSE_FAILED . ',"errorMessage":"Failed to encode JSON response. Error: JSON_RESPONSE_FAILED (LS-' . LOGIN_ERROR_JSON_RESPONSE_FAILED . ')."}';
+	}
+
+	die($response);
+}
+
+function loginPublicErrorMessage($message, $name, $code)
+{
+	return $message . ' Error: ' . $name . ' (LS-' . $code . ').';
+}
+
+function loginAdminHint($name)
+{
+	switch ($name) {
+		case 'ACCOUNT_DATA_UNAVAILABLE':
+			return 'Check the accounts table schema and database connectivity; MyAAC needs the login identifier and password columns, and may use type, group_id or web_flags to identify admin accounts when those columns exist.';
+		case 'CHARACTER_LIST_LOAD_FAILED':
+			return 'Check the players table schema for the configured server base, especially account_id, name, level, sex, vocation, outfit and deletion columns.';
+		case 'ACCOUNT_EMAIL_NOT_VERIFIED':
+			return 'Verify the account email in the website database, or disable account_mail_verify if this server does not use website email verification.';
+		case 'TWO_FACTOR_TOKEN_REQUIRED':
+		case 'TWO_FACTOR_TOKEN_INVALID':
+			return 'Check the account secret column and the authenticator clock; clear the account secret only if you intentionally want to disable 2FA for this account.';
+		case 'LOGIN_RATE_LIMITED':
+			return 'Clear the failed_logins rate limit cache or wait for the configured account_login_ban_time before testing this account again.';
+		case 'LOGIN_SERVICE_UNAVAILABLE':
+			return 'Check system/logs/login-errors.log and the web server PHP error log for the root cause.';
+		default:
+			return '';
+	}
+}
+
+function appendLoginAdminHint($message, $name, $includeAdminHint)
+{
+	if (!$includeAdminHint) {
+		return $message;
+	}
+
+	$hint = loginAdminHint($name);
+	if ($hint === '') {
+		return $message;
+	}
+
+	return $message . ' Admin hint: ' . $hint;
+}
+
+function logLoginDiagnostic($name, $code, $cause = null, array $context = [])
+{
+	$details = [
+		'name' => $name,
+		'code' => $code
+	];
+
+	if ($cause instanceof Throwable) {
+		$details['cause'] = get_class($cause) . ': ' . $cause->getMessage();
+		$details['file'] = $cause->getFile();
+		$details['line'] = $cause->getLine();
+	} else if ($cause !== null) {
+		$details['cause'] = (string)$cause;
+	}
+
+	if (!empty($context)) {
+		$details['context'] = $context;
+	}
+
+	try {
+		log_append('login-errors.log', '[' . $name . '] ' . json_encode($details));
+	} catch (Throwable $error) {
+		error_log('[login.php][' . $name . '] ' . print_r($details, true));
+	}
+}
+
+function sendPublicError($code, $name, $message, $cause = null, array $context = [], $includeAdminHint = false)
+{
+	if ($cause !== null || !empty($context)) {
+		logLoginDiagnostic($name, $code, $cause, $context);
+	}
+
+	$message = appendLoginAdminHint($message, $name, $includeAdminHint);
+	sendError(loginPublicErrorMessage($message, $name, $code), $code);
+}
+
+function loginAccountReceivesAdminHints($account)
+{
+	if (!$account) {
+		return false;
+	}
+
+	$webFlags = isset($account->web_flags) ? intval($account->web_flags) : 0;
+	$adminFlag = defined('FLAG_ADMIN') ? FLAG_ADMIN : 1;
+	$superAdminFlag = defined('FLAG_SUPER_ADMIN') ? FLAG_SUPER_ADMIN : 2;
+	if (($webFlags & $adminFlag) === $adminFlag || ($webFlags & $superAdminFlag) === $superAdminFlag) {
+		return true;
+	}
+
+	if (isset($account->type) && intval($account->type) >= LOGIN_ACCOUNT_TYPE_GAMEMASTER) {
+		return true;
+	}
+
+	if (isset($account->group_id) && intval($account->group_id) >= LOGIN_ACCOUNT_GROUP_GAMEMASTER) {
+		return true;
+	}
+
+	return false;
 }
 
 function encodeJsonResponse($data)
 {
 	$response = json_encode($data);
 	if ($response === false) {
-		sendError('Failed to encode JSON response.', 500);
+		sendPublicError(
+			LOGIN_ERROR_JSON_RESPONSE_FAILED,
+			'JSON_RESPONSE_FAILED',
+			'Failed to encode JSON response.',
+			json_last_error_msg()
+		);
 	}
 
 	return $response;
@@ -142,7 +278,7 @@ function createEventScheduleJsonEntry($event)
 	];
 }
 
-function loadEventScheduleFromJson($filePath)
+function loadEventScheduleFromJson($filePath, &$error = null)
 {
 	if (!file_exists($filePath)) {
 		return null;
@@ -150,15 +286,18 @@ function loadEventScheduleFromJson($filePath)
 
 	$content = file_get_contents($filePath);
 	if ($content === false) {
+		$error = "Cannot read event scheduler JSON file: {$filePath}";
 		return null;
 	}
 
 	$json = json_decode($content, true);
 	if (json_last_error() !== JSON_ERROR_NONE) {
+		$error = "Invalid event scheduler JSON file {$filePath}: " . json_last_error_msg();
 		return null;
 	}
 
 	if (!is_array($json) || !isset($json['events']) || !is_array($json['events'])) {
+		$error = "Invalid event scheduler JSON structure in {$filePath}: missing events array.";
 		return null;
 	}
 
@@ -175,7 +314,7 @@ function loadEventScheduleFromJson($filePath)
 	return $eventlist;
 }
 
-function loadEventScheduleFromXml($filePath)
+function loadEventScheduleFromXml($filePath, &$error = null)
 {
 	if (!file_exists($filePath)) {
 		return null;
@@ -188,6 +327,7 @@ function loadEventScheduleFromXml($filePath)
 	libxml_clear_errors();
 	libxml_use_internal_errors($previousUseInternalErrors);
 	if ($loaded === false) {
+		$error = "Invalid event scheduler XML file: {$filePath}";
 		return null;
 	}
 
@@ -399,8 +539,27 @@ function getBoostedCreatureResponse($db)
 
 	$clientVersion = (int)setting('core.client');
 	if ($clientVersion >= 1340) {
-		$creatureBoostQuery = $db->query("SELECT `raceid` FROM " . $db->tableName('boosted_creature') . " LIMIT 1");
-		$bossBoostQuery = $db->query("SELECT `raceid` FROM " . $db->tableName('boosted_boss') . " LIMIT 1");
+		try {
+			$creatureBoostQuery = $db->query("SELECT `raceid` FROM " . $db->tableName('boosted_creature') . " LIMIT 1");
+			$bossBoostQuery = $db->query("SELECT `raceid` FROM " . $db->tableName('boosted_boss') . " LIMIT 1");
+		} catch (Throwable $error) {
+			sendPublicError(
+				LOGIN_ERROR_BOOSTED_DATA_UNAVAILABLE,
+				'BOOSTED_DATA_UNAVAILABLE',
+				'Boosted creature data is unavailable. Please contact support.',
+				$error
+			);
+		}
+
+		if ($creatureBoostQuery === false || $bossBoostQuery === false) {
+			sendPublicError(
+				LOGIN_ERROR_BOOSTED_DATA_UNAVAILABLE,
+				'BOOSTED_DATA_UNAVAILABLE',
+				'Boosted creature data is unavailable. Please contact support.',
+				'boosted_creature or boosted_boss query failed'
+			);
+		}
+
 		$creatureBoost = $creatureBoostQuery !== false ? $creatureBoostQuery->fetch(PDO::FETCH_ASSOC) : false;
 		$bossBoost = $bossBoostQuery !== false ? $bossBoostQuery->fetch(PDO::FETCH_ASSOC) : false;
 		return cacheBoostedCreatureResponse($signature, encodeJsonResponse([
@@ -410,7 +569,17 @@ function getBoostedCreatureResponse($db)
 		]));
 	}
 
-	$boostedCreature = BoostedCreature::first();
+	try {
+		$boostedCreature = BoostedCreature::first();
+	} catch (Throwable $error) {
+		sendPublicError(
+			LOGIN_ERROR_BOOSTED_DATA_UNAVAILABLE,
+			'BOOSTED_DATA_UNAVAILABLE',
+			'Boosted creature data is unavailable. Please contact support.',
+			$error
+		);
+	}
+
 	return cacheBoostedCreatureResponse($signature, encodeJsonResponse([
 		'boostedcreature' => true,
 		'raceid' => $boostedCreature->raceid ?? 0
@@ -425,6 +594,17 @@ function isLivestreamLogin($value)
 function getLivestreamUnavailableMessage()
 {
 	return 'No active livestream casters found, or livestream login is disabled.';
+}
+
+function sendLivestreamUnavailable($cause = null, array $context = [])
+{
+	sendPublicError(
+		LOGIN_ERROR_LIVESTREAM_UNAVAILABLE,
+		'LIVESTREAM_UNAVAILABLE',
+		getLivestreamUnavailableMessage(),
+		$cause,
+		$context
+	);
 }
 
 function sendLivestreamLogin($db, $world, $password)
@@ -442,17 +622,27 @@ function sendLivestreamLogin($db, $world, $password)
 			ORDER BY lc.livestream_viewers DESC, p.name ASC
 		");
 		if ($liveCastersQuery === false) {
-			sendError('Database query failed', 500);
+			sendPublicError(
+				LOGIN_ERROR_LIVESTREAM_DATA_UNAVAILABLE,
+				'LIVESTREAM_DATA_UNAVAILABLE',
+				'Livestream data is unavailable. Please contact support.',
+				'active_livestream_casters query failed'
+			);
 		}
 
 		$casters = $liveCastersQuery->fetchAll(PDO::FETCH_ASSOC);
 	}
-	catch (PDOException $error) {
+	catch (Throwable $error) {
 		if (stripos($error->getMessage(), 'active_livestream_casters') !== false) {
-			sendError(getLivestreamUnavailableMessage());
+			sendLivestreamUnavailable($error);
 		}
 
-		sendError('Database query failed', 500);
+		sendPublicError(
+			LOGIN_ERROR_LIVESTREAM_DATA_UNAVAILABLE,
+			'LIVESTREAM_DATA_UNAVAILABLE',
+			'Livestream data is unavailable. Please contact support.',
+			$error
+		);
 	}
 
 	$characters = [];
@@ -461,7 +651,7 @@ function sendLivestreamLogin($db, $world, $password)
 	}
 
 	if (empty($characters)) {
-		sendError(getLivestreamUnavailableMessage());
+		sendLivestreamUnavailable(null, ['reason' => 'no active casters']);
 	}
 
 	$worlds = [$world];
@@ -484,12 +674,26 @@ function sendLivestreamLogin($db, $world, $password)
 	die(json_encode(compact('session', 'playdata')));
 }
 
-$request = json_decode(file_get_contents('php://input'));
-$action = $request->type ?? '';
+$requestBody = file_get_contents('php://input');
+$request = json_decode($requestBody);
+if (!is_object($request) || json_last_error() !== JSON_ERROR_NONE) {
+	sendPublicError(
+		LOGIN_ERROR_MALFORMED_REQUEST,
+		'MALFORMED_REQUEST',
+		'Malformed login request. Please restart the client and try again.',
+		json_last_error_msg(),
+		['bodyLength' => is_string($requestBody) ? strlen($requestBody) : 0]
+	);
+}
+
+$action = trim((string)($request->type ?? ''));
 
 /** @var OTS_Base_DB $db */
 /** @var array $config */
 
+$includeAdminHint = false;
+
+try {
 switch ($action) {
 	case 'cacheinfo':
 		$playersonline = PlayerOnline::count();
@@ -503,6 +707,7 @@ switch ($action) {
 
 	case 'eventschedule':
 		$eventScheduleDirectories = getEventScheduleDirectoryPaths();
+		$eventScheduleErrors = [];
 		foreach ($eventScheduleDirectories as $eventScheduleDirectory) {
 			$jsonFilePath = $eventScheduleDirectory . 'json/eventscheduler/events.json';
 			$cachedResponse = getCachedEventScheduleResponse($jsonFilePath, 'json');
@@ -510,9 +715,13 @@ switch ($action) {
 				die($cachedResponse);
 			}
 
-			$eventlist = loadEventScheduleFromJson($jsonFilePath);
+			$error = null;
+			$eventlist = loadEventScheduleFromJson($jsonFilePath, $error);
 			if ($eventlist !== null) {
 				die(cacheEventScheduleResponse($jsonFilePath, 'json', $eventlist));
+			}
+			if ($error !== null) {
+				$eventScheduleErrors[] = $error;
 			}
 		}
 
@@ -523,10 +732,23 @@ switch ($action) {
 				die($cachedResponse);
 			}
 
-			$eventlist = loadEventScheduleFromXml($xmlFilePath);
+			$error = null;
+			$eventlist = loadEventScheduleFromXml($xmlFilePath, $error);
 			if ($eventlist !== null) {
 				die(cacheEventScheduleResponse($xmlFilePath, 'xml', $eventlist));
 			}
+			if ($error !== null) {
+				$eventScheduleErrors[] = $error;
+			}
+		}
+
+		if (!empty($eventScheduleErrors)) {
+			sendPublicError(
+				LOGIN_ERROR_EVENT_SCHEDULE_UNAVAILABLE,
+				'EVENT_SCHEDULE_UNAVAILABLE',
+				'Event schedule data is unavailable. Please contact support.',
+				implode(' | ', $eventScheduleErrors)
+			);
 		}
 
 		die(json_encode([]));
@@ -567,15 +789,42 @@ switch ($action) {
 			sendLivestreamLogin($db, $world, $request->password ?? '');
 		}
 
-		$account = Account::query();
-		if ($inputEmail != false) { // login by email
-			$account->where('email', $inputEmail);
-		}
-		else if($inputAccountName != false) { // login by account name
-			$account->where('name', $inputAccountName);
+		if ($inputEmail === false && $inputAccountName === false) {
+			sendPublicError(
+				LOGIN_ERROR_MALFORMED_REQUEST,
+				'MALFORMED_REQUEST',
+				'Malformed login request. Please restart the client and try again.',
+				'missing email/accountname'
+			);
 		}
 
-		$account = $account->first();
+		if (!isset($request->password)) {
+			sendPublicError(
+				LOGIN_ERROR_MALFORMED_REQUEST,
+				'MALFORMED_REQUEST',
+				'Malformed login request. Please restart the client and try again.',
+				'missing password'
+			);
+		}
+
+		try {
+			$account = Account::query();
+			if ($inputEmail != false) { // login by email
+				$account->where('email', $inputEmail);
+			}
+			else if($inputAccountName != false) { // login by account name
+				$account->where('name', $inputAccountName);
+			}
+
+			$account = $account->first();
+		} catch (Throwable $error) {
+			sendPublicError(
+				LOGIN_ERROR_ACCOUNT_DATA_UNAVAILABLE,
+				'ACCOUNT_DATA_UNAVAILABLE',
+				'Account data is unavailable. Please contact support.',
+				$error
+			);
+		}
 
 		$ip = get_browser_real_ip();
 		$limiter = new RateLimit('failed_logins', setting('core.account_login_attempts_limit'), setting('core.account_login_ban_time'));
@@ -586,22 +835,39 @@ switch ($action) {
 		if (!$account) {
 			$limiter->increment($ip);
 			if ($limiter->exceeded($ip)) {
-				sendError($ban_msg);
+				sendPublicError(
+					LOGIN_ERROR_INVALID_CREDENTIALS,
+					'LOGIN_RATE_LIMITED',
+					$ban_msg
+				);
 			}
 
-			sendError(($inputEmail != false ? 'Email' : 'Account name') . ' or password is not correct.');
+			sendPublicError(
+				LOGIN_ERROR_INVALID_CREDENTIALS,
+				'INVALID_CREDENTIALS',
+				($inputEmail != false ? 'Email' : 'Account name') . ' or password is not correct.'
+			);
 		}
 
 		$current_password = encrypt((USE_ACCOUNT_SALT ? $account->salt : '') . $request->password);
 		if (!$account || $account->password != $current_password) {
 			$limiter->increment($ip);
 			if ($limiter->exceeded($ip)) {
-				sendError($ban_msg);
+				sendPublicError(
+					LOGIN_ERROR_INVALID_CREDENTIALS,
+					'LOGIN_RATE_LIMITED',
+					$ban_msg
+				);
 			}
 
-			sendError(($inputEmail != false ? 'Email' : 'Account name') . ' or password is not correct.');
+			sendPublicError(
+				LOGIN_ERROR_INVALID_CREDENTIALS,
+				'INVALID_CREDENTIALS',
+				($inputEmail != false ? 'Email' : 'Account name') . ' or password is not correct.'
+			);
 		}
 
+		$includeAdminHint = loginAccountReceivesAdminHints($account);
 		$accountHasSecret = false;
 		if (fieldExist('secret', 'accounts')) {
 			$accountSecret = $account->secret;
@@ -610,18 +876,46 @@ switch ($action) {
 				if ($inputToken === false) {
 					$limiter->increment($ip);
 					if ($limiter->exceeded($ip)) {
-						sendError($ban_msg);
+						sendPublicError(
+							LOGIN_ERROR_INVALID_CREDENTIALS,
+							'LOGIN_RATE_LIMITED',
+							$ban_msg,
+							null,
+							[],
+							$includeAdminHint
+						);
 					}
-					sendError('Submit a valid two-factor authentication token.', 6);
+					sendPublicError(
+						LOGIN_ERROR_TWO_FACTOR_REQUIRED,
+						'TWO_FACTOR_TOKEN_REQUIRED',
+						'Submit a valid two-factor authentication token.',
+						null,
+						[],
+						$includeAdminHint
+					);
 				} else {
 					require_once LIBS . 'rfc6238.php';
 					if (TokenAuth6238::verify($accountSecret, $inputToken) !== true) {
 						$limiter->increment($ip);
 						if ($limiter->exceeded($ip)) {
-							sendError($ban_msg);
+							sendPublicError(
+								LOGIN_ERROR_INVALID_CREDENTIALS,
+								'LOGIN_RATE_LIMITED',
+								$ban_msg,
+								null,
+								[],
+								$includeAdminHint
+							);
 						}
 
-						sendError('Two-factor authentication failed, token is wrong.', 6);
+						sendPublicError(
+							LOGIN_ERROR_TWO_FACTOR_REQUIRED,
+							'TWO_FACTOR_TOKEN_INVALID',
+							'Two-factor authentication failed, token is wrong.',
+							null,
+							[],
+							$includeAdminHint
+						);
 					}
 				}
 			}
@@ -629,7 +923,14 @@ switch ($action) {
 
 		$limiter->reset($ip);
 		if (setting('core.account_mail_verify') && $account->email_verified !== 1) {
-			sendError('You need to verify your account, enter in our site and resend verify e-mail!');
+			sendPublicError(
+				LOGIN_ERROR_INVALID_CREDENTIALS,
+				'ACCOUNT_EMAIL_NOT_VERIFIED',
+				'You need to verify your account, enter in our site and resend verify e-mail.',
+				null,
+				[],
+				$includeAdminHint
+			);
 		}
 
 		// common columns
@@ -643,7 +944,18 @@ switch ($action) {
 			$columns .= ', istutorial';
 		}
 
-		$players = Player::where('account_id', $account->id)->notDeleted()->selectRaw($columns)->get();
+		try {
+			$players = Player::where('account_id', $account->id)->notDeleted()->selectRaw($columns)->get();
+		} catch (Throwable $error) {
+			sendPublicError(
+				LOGIN_ERROR_CHARACTER_LIST_LOAD_FAILED,
+				'CHARACTER_LIST_LOAD_FAILED',
+				'Character list is unavailable. Please contact support.',
+				$error,
+				[],
+				$includeAdminHint
+			);
+		}
 		if($players && $players->count()) {
 			$highestLevelId = $players->sortByDesc('experience')->first()->getKey();
 
@@ -727,8 +1039,24 @@ switch ($action) {
 		die(json_encode(compact('session', 'playdata')));
 
 	default:
-		sendError("Unrecognized event {$action}.");
+		sendPublicError(
+			LOGIN_ERROR_UNSUPPORTED_REQUEST_TYPE,
+			'UNSUPPORTED_REQUEST_TYPE',
+			'Unsupported login request type. Please restart the client and try again.',
+			null,
+			['type' => $action]
+		);
 	break;
+}
+} catch (Throwable $error) {
+	sendPublicError(
+		LOGIN_ERROR_LOGIN_SERVICE_UNAVAILABLE,
+		'LOGIN_SERVICE_UNAVAILABLE',
+		'Login service error. Please contact support.',
+		$error,
+		['type' => $action],
+		$includeAdminHint
+	);
 }
 
 function create_char($player, $highestLevelId) {

--- a/login.php
+++ b/login.php
@@ -27,6 +27,7 @@ const LOGIN_ERROR_LIVESTREAM_UNAVAILABLE = 4003;
 const LOGIN_ERROR_LIVESTREAM_DATA_UNAVAILABLE = 4004;
 const LOGIN_ACCOUNT_TYPE_GAMEMASTER = 4;
 const LOGIN_ACCOUNT_GROUP_GAMEMASTER = 4;
+const LOGIN_EVENT_SCHEDULE_CACHE_TTL = 7 * 24 * 60 * 60;
 
 # error function
 function sendError($message, $code = 3){
@@ -149,6 +150,16 @@ function loginAccountReceivesAdminHints($account)
 	}
 
 	return false;
+}
+
+function normalizeLoginIdentifier($value)
+{
+	if (!is_string($value)) {
+		return false;
+	}
+
+	$value = trim($value);
+	return $value === '' ? false : $value;
 }
 
 function encodeJsonResponse($data)
@@ -323,7 +334,7 @@ function loadEventScheduleFromXml($filePath, &$error = null)
 	$xml = new DOMDocument;
 	$previousUseInternalErrors = libxml_use_internal_errors(true);
 	libxml_clear_errors();
-	$loaded = $xml->load($filePath);
+	$loaded = $xml->load($filePath, defined('LIBXML_NONET') ? LIBXML_NONET : 0);
 	libxml_clear_errors();
 	libxml_use_internal_errors($previousUseInternalErrors);
 	if ($loaded === false) {
@@ -371,7 +382,10 @@ function buildServerDirectoryPath($directory)
 	}
 
 	if (!isAbsoluteServerPath($directory)) {
-		$directory = config('server_path') . $directory;
+		$serverPath = rtrim((string)config('server_path'), "/\\");
+		if ($serverPath !== '') {
+			$directory = $serverPath . '/' . ltrim($directory, "/\\");
+		}
 	}
 
 	$lastChar = $directory[strlen($directory) - 1] ?? '';
@@ -462,7 +476,7 @@ function cacheEventScheduleResponse($filePath, $format, $eventlist)
 		$cache->set(
 			getEventScheduleCacheKey($filePath, $format),
 			$payload,
-			10 * 365 * 24 * 60 * 60
+			LOGIN_EVENT_SCHEDULE_CACHE_TTL
 		);
 	}
 
@@ -671,7 +685,7 @@ function sendLivestreamLogin($db, $world, $password)
 		'emailcoderequest' => false
 	];
 
-	die(json_encode(compact('session', 'playdata')));
+	sendJsonResponse(compact('session', 'playdata'));
 }
 
 $requestBody = file_get_contents('php://input');
@@ -697,13 +711,13 @@ try {
 switch ($action) {
 	case 'cacheinfo':
 		$playersonline = PlayerOnline::count();
-		die(json_encode([
+		sendJsonResponse([
 			'playersonline' => $playersonline,
 			'twitchstreams' => 0,
 			'twitchviewer' => 0,
 			'gamingyoutubestreams' => 0,
 			'gamingyoutubeviewer' => 0
-		]));
+		]);
 
 	case 'eventschedule':
 		$eventScheduleDirectories = getEventScheduleDirectoryPaths();
@@ -751,7 +765,7 @@ switch ($action) {
 			);
 		}
 
-		die(json_encode([]));
+		sendJsonResponse([]);
 
 	case 'boostedcreature':
 		die(getBoostedCreatureResponse($db));
@@ -781,8 +795,8 @@ switch ($action) {
 
 		$characters = [];
 
-		$inputEmail = $request->email ?? false;
-		$inputAccountName = $request->accountname ?? false;
+		$inputEmail = normalizeLoginIdentifier($request->email ?? false);
+		$inputAccountName = normalizeLoginIdentifier($request->accountname ?? false);
 		$inputToken = $request->token ?? false;
 
 		if (isLivestreamLogin($inputEmail) || isLivestreamLogin($inputAccountName)) {
@@ -809,10 +823,10 @@ switch ($action) {
 
 		try {
 			$account = Account::query();
-			if ($inputEmail != false) { // login by email
+			if ($inputEmail !== false) { // login by email
 				$account->where('email', $inputEmail);
 			}
-			else if($inputAccountName != false) { // login by account name
+			else if($inputAccountName !== false) { // login by account name
 				$account->where('name', $inputAccountName);
 			}
 
@@ -845,7 +859,7 @@ switch ($action) {
 			sendPublicError(
 				LOGIN_ERROR_INVALID_CREDENTIALS,
 				'INVALID_CREDENTIALS',
-				($inputEmail != false ? 'Email' : 'Account name') . ' or password is not correct.'
+				($inputEmail !== false ? 'Email' : 'Account name') . ' or password is not correct.'
 			);
 		}
 
@@ -863,7 +877,7 @@ switch ($action) {
 			sendPublicError(
 				LOGIN_ERROR_INVALID_CREDENTIALS,
 				'INVALID_CREDENTIALS',
-				($inputEmail != false ? 'Email' : 'Account name') . ' or password is not correct.'
+				($inputEmail !== false ? 'Email' : 'Account name') . ' or password is not correct.'
 			);
 		}
 
@@ -1036,7 +1050,7 @@ switch ($action) {
 			'tournamentticketpurchasestate' => 0,
 			'emailcoderequest' => false
 		];
-		die(json_encode(compact('session', 'playdata')));
+		sendJsonResponse(compact('session', 'playdata'));
 
 	default:
 		sendPublicError(

--- a/login.php
+++ b/login.php
@@ -294,14 +294,12 @@ function cacheEventScheduleResponse($filePath, $format, $eventlist)
 	$response = encodeJsonResponse(['eventlist' => $eventlist, 'lastupdatetimestamp' => time()]);
 	$cache = Cache::getInstance();
 	if ($cache->enabled()) {
-		$payload = json_encode(array_merge(getEventScheduleFileSignature($filePath), ['response' => $response]));
-		if ($payload !== false) {
-			$cache->set(
-				getEventScheduleCacheKey($filePath, $format),
-				$payload,
-				10 * 365 * 24 * 60 * 60
-			);
-		}
+		$payload = encodeJsonResponse(array_merge(getEventScheduleFileSignature($filePath), ['response' => $response]));
+		$cache->set(
+			getEventScheduleCacheKey($filePath, $format),
+			$payload,
+			10 * 365 * 24 * 60 * 60
+		);
 	}
 
 	return $response;

--- a/login.php
+++ b/login.php
@@ -97,23 +97,37 @@ function parseEventSchedulerXmlValue($table, $attribute, $default = '')
 	return $value === 'error' ? $default : $value;
 }
 
+function getEventScheduleJsonField($event, $field, $default = '')
+{
+	return array_key_exists($field, $event) ? (string)$event[$field] : $default;
+}
+
+function getEventScheduleJsonSection($event, $field)
+{
+	if (!isset($event[$field]) || !is_array($event[$field])) {
+		return [];
+	}
+
+	return $event[$field];
+}
+
 function createEventScheduleJsonEntry($event)
 {
 	if (!is_array($event)) {
 		return null;
 	}
 
-	$defaultHour = isset($event['hour']) ? (string)$event['hour'] : '';
-	$startHour = isset($event['starthour']) ? (string)$event['starthour'] : $defaultHour;
-	$endHour = isset($event['endhour']) ? (string)$event['endhour'] : $defaultHour;
+	$defaultHour = getEventScheduleJsonField($event, 'hour');
+	$startHour = getEventScheduleJsonField($event, 'starthour', $defaultHour);
+	$endHour = getEventScheduleJsonField($event, 'endhour', $defaultHour);
 	$startDate = parseEventSchedulerJsonDate($event['startdate'] ?? '', $startHour);
 	$endDate = parseEventSchedulerJsonDate($event['enddate'] ?? '', $endHour, true);
 	if ($startDate === null || $endDate === null) {
 		return null;
 	}
 
-	$colors = isset($event['colors']) && is_array($event['colors']) ? $event['colors'] : [];
-	$details = isset($event['details']) && is_array($event['details']) ? $event['details'] : [];
+	$colors = getEventScheduleJsonSection($event, 'colors');
+	$details = getEventScheduleJsonSection($event, 'details');
 
 	return [
 		'colorlight' => (string)($colors['colorlight'] ?? ''),

--- a/login.php
+++ b/login.php
@@ -4,6 +4,7 @@ use MyAAC\Models\BoostedCreature;
 use MyAAC\Models\PlayerOnline;
 use MyAAC\Models\Account;
 use MyAAC\Models\Player;
+use MyAAC\Cache\Cache;
 use MyAAC\RateLimit;
 
 require_once 'common.php';
@@ -42,6 +43,369 @@ function parseEvent($table1, $date, $table2)
 	return 'error';
 }
 
+function parseEventSchedulerJsonDate($date, $hour, $endDate = false)
+{
+	$date = trim((string)$date);
+	$hour = trim((string)$hour);
+	if ($date === '') {
+		return null;
+	}
+
+	if ($hour === '') {
+		$hour = $endDate ? '23:59:59' : '00:00:00';
+	}
+	else if (preg_match('/^\d{1,2}:\d{2}$/', $hour)) {
+		$hour .= ':00';
+	}
+
+	foreach (['!m/d/Y H:i:s', '!n/j/Y H:i:s', '!Y-m-d H:i:s'] as $format) {
+		$dateTime = DateTimeImmutable::createFromFormat($format, "{$date} {$hour}");
+		$errors = DateTimeImmutable::getLastErrors();
+		if ($dateTime !== false && ($errors === false || ($errors['warning_count'] === 0 && $errors['error_count'] === 0))) {
+			return $dateTime->getTimestamp();
+		}
+	}
+
+	$timestamp = strtotime("{$date} {$hour}");
+	return $timestamp !== false ? $timestamp : null;
+}
+
+function loadEventScheduleFromJson($filePath)
+{
+	if (!file_exists($filePath)) {
+		return null;
+	}
+
+	$json = json_decode(file_get_contents($filePath), true);
+	if (!is_array($json) || !isset($json['events']) || !is_array($json['events'])) {
+		return [];
+	}
+
+	$eventlist = [];
+	foreach ($json['events'] as $event) {
+		if (!is_array($event)) {
+			continue;
+		}
+
+		$defaultHour = isset($event['hour']) ? (string)$event['hour'] : '';
+		$startHour = isset($event['starthour']) ? (string)$event['starthour'] : $defaultHour;
+		$endHour = isset($event['endhour']) ? (string)$event['endhour'] : $defaultHour;
+		$startDate = parseEventSchedulerJsonDate($event['startdate'] ?? '', $startHour);
+		$endDate = parseEventSchedulerJsonDate($event['enddate'] ?? '', $endHour, true);
+		if ($startDate === null || $endDate === null) {
+			continue;
+		}
+
+		$colors = isset($event['colors']) && is_array($event['colors']) ? $event['colors'] : [];
+		$details = isset($event['details']) && is_array($event['details']) ? $event['details'] : [];
+
+		$eventlist[] = [
+			'colorlight' => (string)($colors['colorlight'] ?? ''),
+			'colordark' => (string)($colors['colordark'] ?? ''),
+			'description' => (string)($event['description'] ?? ''),
+			'displaypriority' => intval($details['displaypriority'] ?? 0),
+			'enddate' => intval($endDate),
+			'isseasonal' => getBoolean($details['isseasonal'] ?? false),
+			'name' => (string)($event['name'] ?? ''),
+			'startdate' => intval($startDate),
+			'specialevent' => intval($details['specialevent'] ?? 0)
+		];
+	}
+
+	return $eventlist;
+}
+
+function loadEventScheduleFromXml($filePath)
+{
+	if (!file_exists($filePath)) {
+		return null;
+	}
+
+	$xml = new DOMDocument;
+	if (@$xml->load($filePath) === false) {
+		return [];
+	}
+
+	$eventlist = [];
+	$tableevent = $xml->getElementsByTagName('event');
+	foreach ($tableevent as $event) {
+		if ($event) {
+			$eventlist[] = [
+				'colorlight' => parseEvent($event->getElementsByTagName('colors'), false, 'colorlight'),
+				'colordark' => parseEvent($event->getElementsByTagName('colors'), false, 'colordark'),
+				'description' => parseEvent($event->getElementsByTagName('description'), false, 'description'),
+				'displaypriority' => intval(parseEvent($event->getElementsByTagName('details'), false, 'displaypriority')),
+				'enddate' => intval(parseEvent($event, true, false)),
+				'isseasonal' => getBoolean(intval(parseEvent($event->getElementsByTagName('details'), false, 'isseasonal'))),
+				'name' => $event->getAttribute('name'),
+				'startdate' => intval(parseEvent($event, true, true)),
+				'specialevent' => intval(parseEvent($event->getElementsByTagName('details'), false, 'specialevent'))
+			];
+		}
+	}
+
+	return $eventlist;
+}
+
+function isAbsoluteServerPath($path)
+{
+	return preg_match('/^(?:[A-Za-z]:[\/\\\\]|[\/\\\\])/', (string)$path) === 1;
+}
+
+function buildServerDirectoryPath($directory)
+{
+	$directory = trim((string)$directory);
+	if ($directory === '') {
+		$directory = 'data';
+	}
+
+	if (!isAbsoluteServerPath($directory)) {
+		$directory = config('server_path') . $directory;
+	}
+
+	$lastChar = $directory[strlen($directory) - 1] ?? '';
+	if ($lastChar !== '/' && $lastChar !== '\\') {
+		$directory .= '/';
+	}
+
+	return $directory;
+}
+
+function getEventScheduleDirectoryPaths()
+{
+	$directories = [];
+	$addDirectory = static function ($directory) use (&$directories) {
+		if (!is_string($directory) || trim($directory) === '') {
+			return;
+		}
+
+		$directory = buildServerDirectoryPath($directory);
+		if (!in_array($directory, $directories, true)) {
+			$directories[] = $directory;
+		}
+	};
+
+	foreach (['coreDirectory', 'dataDirectory', 'data_directory', 'datadir'] as $key) {
+		$addDirectory(configLua($key));
+	}
+
+	$addDirectory(config('data_path'));
+	$addDirectory('data');
+
+	return $directories;
+}
+
+function getEventScheduleCacheKey($filePath, $format)
+{
+	return 'login_eventschedule_' . sha1($format . ':' . $filePath);
+}
+
+function getEventScheduleFileSignature($filePath)
+{
+	return [
+		'mtime' => @filemtime($filePath) ?: 0,
+		'size' => @filesize($filePath) ?: 0
+	];
+}
+
+function getCachedEventScheduleResponse($filePath, $format)
+{
+	if (!is_file($filePath)) {
+		return null;
+	}
+
+	$cache = Cache::getInstance();
+	if (!$cache->enabled()) {
+		return null;
+	}
+
+	$payload = null;
+	if (!$cache->fetch(getEventScheduleCacheKey($filePath, $format), $payload) || !is_string($payload)) {
+		return null;
+	}
+
+	$cached = @unserialize($payload);
+	$signature = getEventScheduleFileSignature($filePath);
+	if (
+		is_array($cached)
+		&& ($cached['mtime'] ?? null) === $signature['mtime']
+		&& ($cached['size'] ?? null) === $signature['size']
+		&& is_string($cached['response'] ?? null)
+	) {
+		return $cached['response'];
+	}
+
+	return null;
+}
+
+function cacheEventScheduleResponse($filePath, $format, $eventlist)
+{
+	$response = json_encode(['eventlist' => $eventlist, 'lastupdatetimestamp' => time()]);
+	$cache = Cache::getInstance();
+	if ($cache->enabled()) {
+		$cache->set(
+			getEventScheduleCacheKey($filePath, $format),
+			serialize(getEventScheduleFileSignature($filePath) + ['response' => $response]),
+			10 * 365 * 24 * 60 * 60
+		);
+	}
+
+	return $response;
+}
+
+function getBoostedCreatureCacheSignature()
+{
+	global $status;
+
+	$signature = [
+		'clientVersion' => (int)setting('core.client')
+	];
+
+	if (
+		isset($status['online'], $status['lastCheck'], $status['uptime'])
+		&& getBoolean($status['online'])
+		&& is_numeric($status['lastCheck'])
+		&& is_numeric($status['uptime'])
+		&& intval($status['uptime']) > 0
+		&& intval($status['lastCheck']) > intval($status['uptime'])
+	) {
+		$serverStartedAt = intval($status['lastCheck']) - intval($status['uptime']);
+		$signature['serverStartedAtMinute'] = intdiv($serverStartedAt, 60);
+		return $signature;
+	}
+
+	$signature['date'] = date('Y-m-d');
+	return $signature;
+}
+
+function getBoostedCreatureCacheTtl($signature)
+{
+	return isset($signature['serverStartedAtMinute']) ? 24 * 60 * 60 : 5 * 60;
+}
+
+function getBoostedCreatureCacheKey($signature)
+{
+	return 'login_boostedcreature_' . sha1(json_encode($signature));
+}
+
+function getCachedBoostedCreatureResponse($signature)
+{
+	$cache = Cache::getInstance();
+	if (!$cache->enabled()) {
+		return null;
+	}
+
+	$response = null;
+	if ($cache->fetch(getBoostedCreatureCacheKey($signature), $response) && is_string($response)) {
+		return $response;
+	}
+
+	return null;
+}
+
+function cacheBoostedCreatureResponse($signature, $response)
+{
+	$cache = Cache::getInstance();
+	if ($cache->enabled()) {
+		$cache->set(getBoostedCreatureCacheKey($signature), $response, getBoostedCreatureCacheTtl($signature));
+	}
+
+	return $response;
+}
+
+function getBoostedCreatureResponse($db)
+{
+	$signature = getBoostedCreatureCacheSignature();
+	$cachedResponse = getCachedBoostedCreatureResponse($signature);
+	if ($cachedResponse !== null) {
+		return $cachedResponse;
+	}
+
+	$clientVersion = (int)setting('core.client');
+	if ($clientVersion >= 1340) {
+		$creatureBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_creature'))->fetchAll();
+		$bossBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_boss'))->fetchAll();
+		return cacheBoostedCreatureResponse($signature, json_encode([
+			//'boostedcreature' => true,
+			'bossraceid' => intval($bossBoost[0]['raceid']),
+			'creatureraceid' => intval($creatureBoost[0]['raceid']),
+		]));
+	}
+
+	$boostedCreature = BoostedCreature::first();
+	return cacheBoostedCreatureResponse($signature, json_encode([
+		'boostedcreature' => true,
+		'raceid' => $boostedCreature->raceid
+	]));
+}
+
+function isLivestreamLogin($value)
+{
+	return strtolower(trim((string)$value)) === '@livestream';
+}
+
+function getLivestreamUnavailableMessage()
+{
+	return 'No active livestream casters found, or livestream login is disabled.';
+}
+
+function sendLivestreamLogin($db, $world, $password)
+{
+	try {
+		$playersTable = $db->tableName('players');
+		$castersTable = $db->tableName('active_livestream_casters');
+		$promotionColumn = $db->hasColumn('players', 'promotion') ? ', p.promotion' : '';
+		$liveCastersQuery = $db->query("
+			SELECT p.id, p.name, p.level, p.sex, p.vocation, p.looktype, p.lookhead, p.lookbody,
+				p.looklegs, p.lookfeet, p.lookaddons{$promotionColumn}
+			FROM {$playersTable} p
+			INNER JOIN {$castersTable} lc ON p.id = lc.caster_id
+			WHERE lc.livestream_status >= 1
+			ORDER BY lc.livestream_viewers DESC, p.name ASC
+		");
+		if ($liveCastersQuery === false) {
+			sendError('Database query failed', 500);
+		}
+
+		$casters = $liveCastersQuery->fetchAll(PDO::FETCH_ASSOC);
+	}
+	catch (PDOException $error) {
+		if (stripos($error->getMessage(), 'active_livestream_casters') !== false) {
+			sendError(getLivestreamUnavailableMessage());
+		}
+
+		sendError('Database query failed', 500);
+	}
+
+	$characters = [];
+	foreach ($casters as $caster) {
+		$characters[] = create_livestream_char($caster);
+	}
+
+	if (empty($characters)) {
+		sendError(getLivestreamUnavailableMessage());
+	}
+
+	$worlds = [$world];
+	$playdata = compact('worlds', 'characters');
+	$session = [
+		'sessionkey' => "@livestream\n" . (string)$password,
+		'lastlogintime' => 0,
+		'ispremium' => false,
+		'premiumuntil' => 0,
+		'status' => 'active',
+		'returnernotification' => false,
+		'showrewardnews' => false,
+		'isreturner' => false,
+		'fpstracking' => false,
+		'optiontracking' => false,
+		'tournamentticketpurchasestate' => 0,
+		'emailcoderequest' => false
+	];
+
+	die(json_encode(compact('session', 'playdata')));
+}
+
 $request = json_decode(file_get_contents('php://input'));
 $action = $request->type ?? '';
 
@@ -60,51 +424,37 @@ switch ($action) {
 		]));
 
 	case 'eventschedule':
-		$eventlist = [];
-		$file_path = config('server_path') . 'data/XML/events.xml';
-		if (!file_exists($file_path)) {
-			die(json_encode([]));
-		}
-		$xml = new DOMDocument;
-		$xml->load($file_path);
-		$tmplist = [];
-		$tableevent = $xml->getElementsByTagName('event');
+		$eventScheduleDirectories = getEventScheduleDirectoryPaths();
+		foreach ($eventScheduleDirectories as $eventScheduleDirectory) {
+			$jsonFilePath = $eventScheduleDirectory . 'json/eventscheduler/events.json';
+			$cachedResponse = getCachedEventScheduleResponse($jsonFilePath, 'json');
+			if ($cachedResponse !== null) {
+				die($cachedResponse);
+			}
 
-		foreach ($tableevent as $event) {
-			if ($event) { $tmplist = [
-			'colorlight' => parseEvent($event->getElementsByTagName('colors'), false, 'colorlight'),
-			'colordark' => parseEvent($event->getElementsByTagName('colors'), false, 'colordark'),
-			'description' => parseEvent($event->getElementsByTagName('description'), false, 'description'),
-			'displaypriority' => intval(parseEvent($event->getElementsByTagName('details'), false, 'displaypriority')),
-			'enddate' => intval(parseEvent($event, true, false)),
-			'isseasonal' => getBoolean(intval(parseEvent($event->getElementsByTagName('details'), false, 'isseasonal'))),
-			'name' => $event->getAttribute('name'),
-			'startdate' => intval(parseEvent($event, true, true)),
-			'specialevent' => intval(parseEvent($event->getElementsByTagName('details'), false, 'specialevent'))
-				];
-			$eventlist[] = $tmplist; } }
-		die(json_encode(['eventlist' => $eventlist, 'lastupdatetimestamp' => time()]));
+			$eventlist = loadEventScheduleFromJson($jsonFilePath);
+			if ($eventlist !== null) {
+				die(cacheEventScheduleResponse($jsonFilePath, 'json', $eventlist));
+			}
+		}
+
+		foreach ($eventScheduleDirectories as $eventScheduleDirectory) {
+			$xmlFilePath = $eventScheduleDirectory . 'XML/events.xml';
+			$cachedResponse = getCachedEventScheduleResponse($xmlFilePath, 'xml');
+			if ($cachedResponse !== null) {
+				die($cachedResponse);
+			}
+
+			$eventlist = loadEventScheduleFromXml($xmlFilePath);
+			if ($eventlist !== null) {
+				die(cacheEventScheduleResponse($xmlFilePath, 'xml', $eventlist));
+			}
+		}
+
+		die(json_encode([]));
 
 	case 'boostedcreature':
-		$clientVersion = (int)setting('core.client');
-
-		// 13.40 and up
-		if ($clientVersion >= 1340) {
-			$creatureBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_creature'))->fetchAll();
-			$bossBoost     = $db->query("SELECT * FROM " . $db->tableName('boosted_boss'))->fetchAll();
-			die(json_encode([
-				//'boostedcreature' => true,
-				'bossraceid'      => intval($bossBoost[0]['raceid']),
-				'creatureraceid'  => intval($creatureBoost[0]['raceid']),
-			]));
-		}
-
-		// lower clients
-		$boostedCreature = BoostedCreature::first();
-		die(json_encode([
-			'boostedcreature' => true,
-			'raceid' => $boostedCreature->raceid
-		]));
+		die(getBoostedCreatureResponse($db));
 
 	case 'login':
 
@@ -134,6 +484,10 @@ switch ($action) {
 		$inputEmail = $request->email ?? false;
 		$inputAccountName = $request->accountname ?? false;
 		$inputToken = $request->token ?? false;
+
+		if (isLivestreamLogin($inputEmail) || isLivestreamLogin($inputAccountName)) {
+			sendLivestreamLogin($db, $world, $request->password ?? '');
+		}
 
 		$account = Account::query();
 		if ($inputEmail != false) { // login by email
@@ -319,4 +673,35 @@ function create_char($player, $highestLevelId) {
 		'dailyrewardstate' => $player->isreward ?? 0,
 		'remainingdailytournamentplaytime' => 0
 	];
+}
+
+function create_livestream_char($caster) {
+	return [
+		'worldid' => 0,
+		'name' => (string)$caster['name'],
+		'ismale' => intval($caster['sex']) === 1,
+		'tutorial' => false,
+		'level' => intval($caster['level']),
+		'vocation' => get_livestream_vocation_name($caster),
+		'outfitid' => intval($caster['looktype']),
+		'headcolor' => intval($caster['lookhead']),
+		'torsocolor' => intval($caster['lookbody']),
+		'legscolor' => intval($caster['looklegs']),
+		'detailcolor' => intval($caster['lookfeet']),
+		'addonsflags' => intval($caster['lookaddons']),
+		'ishidden' => false,
+		'istournamentparticipant' => false,
+		'ismaincharacter' => false,
+		'dailyrewardstate' => 0,
+		'remainingdailytournamentplaytime' => 0
+	];
+}
+
+function get_livestream_vocation_name($caster) {
+	$vocation = intval($caster['vocation'] ?? 0);
+	if (isset($caster['promotion']) && intval($caster['promotion']) > 0) {
+		$vocation += intval($caster['promotion']) * intval(setting('core.vocations_amount'));
+	}
+
+	return config('vocations')[$vocation] ?? 'Unknown';
 }

--- a/login.php
+++ b/login.php
@@ -20,6 +20,16 @@ function sendError($message, $code = 3){
 	die(json_encode($ret));
 }
 
+function encodeJsonResponse($data)
+{
+	$response = json_encode($data);
+	if ($response === false) {
+		sendError('Failed to encode JSON response.', 500);
+	}
+
+	return $response;
+}
+
 # event schedule function
 function parseEvent($table1, $date, $table2)
 {
@@ -70,15 +80,41 @@ function parseEventSchedulerJsonDate($date, $hour, $endDate = false)
 	return $timestamp !== false ? $timestamp : null;
 }
 
+function parseEventSchedulerXmlDate($event, $attribute)
+{
+	$date = trim((string)$event->getAttribute($attribute));
+	if ($date === '') {
+		return null;
+	}
+
+	$dateTime = date_create($date);
+	return $dateTime !== false ? intval($dateTime->format('U')) : null;
+}
+
+function parseEventSchedulerXmlValue($table, $attribute, $default = '')
+{
+	$value = parseEvent($table, false, $attribute);
+	return $value === 'error' ? $default : $value;
+}
+
 function loadEventScheduleFromJson($filePath)
 {
 	if (!file_exists($filePath)) {
 		return null;
 	}
 
-	$json = json_decode(file_get_contents($filePath), true);
+	$content = file_get_contents($filePath);
+	if ($content === false) {
+		return null;
+	}
+
+	$json = json_decode($content, true);
+	if (json_last_error() !== JSON_ERROR_NONE) {
+		return null;
+	}
+
 	if (!is_array($json) || !isset($json['events']) || !is_array($json['events'])) {
-		return [];
+		return null;
 	}
 
 	$eventlist = [];
@@ -122,24 +158,35 @@ function loadEventScheduleFromXml($filePath)
 	}
 
 	$xml = new DOMDocument;
-	if (@$xml->load($filePath) === false) {
-		return [];
+	$previousUseInternalErrors = libxml_use_internal_errors(true);
+	libxml_clear_errors();
+	$loaded = $xml->load($filePath);
+	libxml_clear_errors();
+	libxml_use_internal_errors($previousUseInternalErrors);
+	if ($loaded === false) {
+		return null;
 	}
 
 	$eventlist = [];
 	$tableevent = $xml->getElementsByTagName('event');
 	foreach ($tableevent as $event) {
 		if ($event) {
+			$startDate = parseEventSchedulerXmlDate($event, 'startdate');
+			$endDate = parseEventSchedulerXmlDate($event, 'enddate');
+			if ($startDate === null || $endDate === null) {
+				continue;
+			}
+
 			$eventlist[] = [
-				'colorlight' => parseEvent($event->getElementsByTagName('colors'), false, 'colorlight'),
-				'colordark' => parseEvent($event->getElementsByTagName('colors'), false, 'colordark'),
-				'description' => parseEvent($event->getElementsByTagName('description'), false, 'description'),
-				'displaypriority' => intval(parseEvent($event->getElementsByTagName('details'), false, 'displaypriority')),
-				'enddate' => intval(parseEvent($event, true, false)),
-				'isseasonal' => getBoolean(intval(parseEvent($event->getElementsByTagName('details'), false, 'isseasonal'))),
+				'colorlight' => parseEventSchedulerXmlValue($event->getElementsByTagName('colors'), 'colorlight'),
+				'colordark' => parseEventSchedulerXmlValue($event->getElementsByTagName('colors'), 'colordark'),
+				'description' => parseEventSchedulerXmlValue($event->getElementsByTagName('description'), 'description'),
+				'displaypriority' => intval(parseEventSchedulerXmlValue($event->getElementsByTagName('details'), 'displaypriority', 0)),
+				'enddate' => $endDate,
+				'isseasonal' => getBoolean(intval(parseEventSchedulerXmlValue($event->getElementsByTagName('details'), 'isseasonal', 0))),
 				'name' => $event->getAttribute('name'),
-				'startdate' => intval(parseEvent($event, true, true)),
-				'specialevent' => intval(parseEvent($event->getElementsByTagName('details'), false, 'specialevent'))
+				'startdate' => $startDate,
+				'specialevent' => intval(parseEventSchedulerXmlValue($event->getElementsByTagName('details'), 'specialevent', 0))
 			];
 		}
 	}
@@ -224,7 +271,11 @@ function getCachedEventScheduleResponse($filePath, $format)
 		return null;
 	}
 
-	$cached = @unserialize($payload);
+	$cached = json_decode($payload, true);
+	if (json_last_error() !== JSON_ERROR_NONE) {
+		return null;
+	}
+
 	$signature = getEventScheduleFileSignature($filePath);
 	if (
 		is_array($cached)
@@ -240,14 +291,17 @@ function getCachedEventScheduleResponse($filePath, $format)
 
 function cacheEventScheduleResponse($filePath, $format, $eventlist)
 {
-	$response = json_encode(['eventlist' => $eventlist, 'lastupdatetimestamp' => time()]);
+	$response = encodeJsonResponse(['eventlist' => $eventlist, 'lastupdatetimestamp' => time()]);
 	$cache = Cache::getInstance();
 	if ($cache->enabled()) {
-		$cache->set(
-			getEventScheduleCacheKey($filePath, $format),
-			serialize(getEventScheduleFileSignature($filePath) + ['response' => $response]),
-			10 * 365 * 24 * 60 * 60
-		);
+		$payload = json_encode(array_merge(getEventScheduleFileSignature($filePath), ['response' => $response]));
+		if ($payload !== false) {
+			$cache->set(
+				getEventScheduleCacheKey($filePath, $format),
+				$payload,
+				10 * 365 * 24 * 60 * 60
+			);
+		}
 	}
 
 	return $response;
@@ -323,19 +377,21 @@ function getBoostedCreatureResponse($db)
 
 	$clientVersion = (int)setting('core.client');
 	if ($clientVersion >= 1340) {
-		$creatureBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_creature'))->fetchAll();
-		$bossBoost = $db->query("SELECT * FROM " . $db->tableName('boosted_boss'))->fetchAll();
-		return cacheBoostedCreatureResponse($signature, json_encode([
+		$creatureBoostQuery = $db->query("SELECT `raceid` FROM " . $db->tableName('boosted_creature') . " LIMIT 1");
+		$bossBoostQuery = $db->query("SELECT `raceid` FROM " . $db->tableName('boosted_boss') . " LIMIT 1");
+		$creatureBoost = $creatureBoostQuery !== false ? $creatureBoostQuery->fetch(PDO::FETCH_ASSOC) : false;
+		$bossBoost = $bossBoostQuery !== false ? $bossBoostQuery->fetch(PDO::FETCH_ASSOC) : false;
+		return cacheBoostedCreatureResponse($signature, encodeJsonResponse([
 			//'boostedcreature' => true,
-			'bossraceid' => intval($bossBoost[0]['raceid']),
-			'creatureraceid' => intval($creatureBoost[0]['raceid']),
+			'bossraceid' => intval($bossBoost['raceid'] ?? 0),
+			'creatureraceid' => intval($creatureBoost['raceid'] ?? 0),
 		]));
 	}
 
 	$boostedCreature = BoostedCreature::first();
-	return cacheBoostedCreatureResponse($signature, json_encode([
+	return cacheBoostedCreatureResponse($signature, encodeJsonResponse([
 		'boostedcreature' => true,
-		'raceid' => $boostedCreature->raceid
+		'raceid' => $boostedCreature->raceid ?? 0
 	]));
 }
 


### PR DESCRIPTION
This PR depends on https://github.com/slawkens/myaac/pull/363 and should be reviewed/merged after it.

PR #363 contains the event schedule JSON/XML compatibility, boosted creature cache hardening, and Canary livestream support. This PR builds on top of that work and adds structured login error diagnostics for the same `login.php` endpoint.

## Summary

Adds structured public login errors and local diagnostics to make client login failures actionable without exposing raw PHP/database errors to regular users.

This updates `login.php` to support:

- named `LOGIN_ERROR_*` codes for login, data, service, event schedule, boosted creature, and livestream failures
- consistent JSON error responses using the existing Tibia client `errorCode` / `errorMessage` contract
- HTTP 200 responses for client-facing login errors, preserving the existing login endpoint behavior
- local diagnostic logging to `system/logs/login-errors.log` when technical context exists
- malformed request detection for invalid JSON, missing login identifiers, and missing passwords
- explicit unsupported request type errors instead of generic unrecognized event messages
- safer JSON response encoding fallback if `json_encode` fails

## Admin diagnostics

Adds admin-only troubleshooting hints similar to the approach in opentibiabr/login-server#33: https://github.com/opentibiabr/login-server/pull/33

Admin hints are only appended after the account password has already been verified, so invalid credential responses do not leak whether an account exists or whether it is privileged.

The admin check is compatibility-oriented and supports multiple account schemas:

- MyAAC `web_flags` admin/super-admin flags when available
- Canary-style `accounts.type >= 4` when available
- `accounts.group_id >= 4` when available on other/custom bases

All checks are optional and guarded, so servers without `type` or `group_id` columns keep the normal public error messages.

## Hardened failure paths

Adds structured errors around failure paths that previously produced generic client errors or internal server errors:

- account lookup/database failures
- character list loading failures
- two-factor token required/invalid responses
- login rate limit responses
- email verification failures
- malformed request payloads
- event schedule JSON/XML parsing errors
- boosted creature/boss query failures
- livestream caster lookup failures
- top-level unexpected login service failures

Technical details are logged locally when available, while the client receives a stable public message such as:

```text
Login service error. Please contact support. Error: LOGIN_SERVICE_UNAVAILABLE (LS-3001).
```

Admin accounts can receive an additional hint after authentication, for example schema or configuration guidance.

## Compatibility

This PR intentionally keeps the existing client-facing response shape and login flow intact.

Regular invalid login responses still use error code `3`, two-factor responses still use code `6`, and the new admin hints are not shown before password verification.

The event schedule/livestream/boosted behavior from #363 remains compatible with older XML-based installs and other MyAAC-supported server bases.

## Related work

- Depends on slawkens/myaac#363: https://github.com/slawkens/myaac/pull/363
- Follows the structured diagnostics approach from opentibiabr/login-server#33: https://github.com/opentibiabr/login-server/pull/33
- The underlying Canary/login-server endpoint support in #363 follows:
  - opentibiabr/login-server#31: https://github.com/opentibiabr/login-server/pull/31
  - opentibiabr/canary#3965: https://github.com/opentibiabr/canary/pull/3965

## Validation

- `php -l login.php`
- `git diff --check`
- local login endpoint smoke tests for valid login, invalid password, and malformed JSON
