### PR TITLE
Feature/settings ext types attr

### DIFF
--- a/system/src/Settings.php
+++ b/system/src/Settings.php
@@ -165,8 +165,8 @@ class Settings implements \ArrayAccess
 		<div class="tab-content" id="tab-content">
 			<?php
 
-			$checkbox = function ($key, $type, $value, $enabled = true) {
-				echo '<label><input type="radio" id="' . $key . '_' . ($type ? 'yes' : 'no') . '" name="settings[' . $key . ']" value="' . ($type ? 'true' : 'false') . '" ' . ($value === $type ? 'checked' : '') . ' ' . ($enabled ? '' : 'disabled') . '/>' . ($type ? 'Yes' : 'No') . '</label> ';
+			$checkbox = function ($key, $type, $value, $extraAttributes = '') {
+				echo '<label><input type="radio" id="' . $key . '_' . ($type ? 'yes' : 'no') . '" name="settings[' . $key . ']" value="' . ($type ? 'true' : 'false') . '" ' . ($value === $type ? 'checked' : '') . ' ' . $extraAttributes . '/>' . ($type ? 'Yes' : 'No') . '</label> ';
 			};
 
 			$i = 0;
@@ -211,6 +211,77 @@ class Settings implements \ArrayAccess
 							<?php
 				}
 
+				$extraAttributes = '';
+				$alreadyAdded = [];
+
+				foreach ([
+					'min',
+					'max',
+					'step',
+					'size',
+					'rows',
+					'cols',
+					'minlength',
+					'maxlength',
+					'placeholder',
+					'pattern',
+					'autocomplete'
+				] as $attr) {
+					if ($setting['type'] === 'textarea' && in_array($attr, ['rows', 'cols'])) {
+						continue;
+					}
+
+					$extraAttributes .= (isset($setting['attrs'][$attr]) ? ' ' . $attr . '="' . $setting['attrs'][$attr] . '"' : '');
+					$alreadyAdded[] = $attr;
+				}
+
+				$attrsDisabled = (isset($setting['attrs']['disabled']) && $setting['attrs']['disabled']);
+
+				foreach ([
+					'readonly',
+					'disabled',
+					'required',
+					'autofocus'
+				] as &$attr) {
+					if (isset($setting['attrs'][$attr]) && !is_bool($setting['attrs'][$attr])) {
+						throw new \RuntimeException("Setting $plugin.$key: attribute '$attr' must be boolean");
+					}
+
+					if ($attr === 'disabled') {
+						$enabled = $setting['enabled'] ?? !$attrsDisabled ?? true;
+
+						if (!$enabled) {
+							$extraAttributes .= (!$enabled ? ' ' . $attr : '');
+						}
+
+						$alreadyAdded[] = $attr;
+						continue;
+					}
+
+					$extraAttributes .= (isset($setting['attrs'][$attr]) && $setting['attrs'][$attr] ? ' ' . $attr : '');
+					$alreadyAdded[] = $attr;
+				}
+
+				foreach ($setting['attrs'] ?? [] as $attr => $value) {
+					if (in_array($attr, $alreadyAdded)) {
+						continue;
+					}
+
+					if (is_bool($value)) {
+						if ($value) {
+							$extraAttributes .= ' ' . $attr;
+						}
+					} else {
+						$extraAttributes .= ' ' . $attr . '="' . $value . '"';
+					}
+				}
+
+				$min = (isset($setting['min']) ? ' min="' . $setting['min'] . '"' : '');
+				$max = (isset($setting['max']) ? ' max="' . $setting['max'] . '"' : '');
+				$step = (isset($setting['step']) ? ' step="' . $setting['step'] . '"' : '');
+
+				$extraAttributes .= $min . $max . $step;
+
 				if (isset($setting['hidden']) && $setting['hidden']) {
 					$value = '';
 					if ($setting['type'] === 'boolean') {
@@ -233,8 +304,8 @@ class Settings implements \ArrayAccess
 						$value = ($setting['default'] ?? false);
 					}
 
-					$checkbox($key, true, $value, $setting['enabled'] ?? true);
-					$checkbox($key, false, $value, $setting['enabled'] ?? true);
+					$checkbox($key, true, $value, $extraAttributes);
+					$checkbox($key, false, $value, $extraAttributes);
 				}
 
 				elseif ($setting['type'] === 'textarea') {
@@ -243,15 +314,19 @@ class Settings implements \ArrayAccess
 					}
 
 					$value = ($settingsDb[$key] ?? ($setting['default'] ?? ''));
-					$valueWithSpaces = array_map('trim', preg_split('/\r\n|\r|\n/', trim($value)));
-					$rows = count($valueWithSpaces);
-					if ($rows < 2) {
-						$rows = 2; // always min 2 rows for textarea
+
+					if (!isset($setting['attrs']['rows'])) {
+						$valueWithSpaces = array_map('trim', preg_split('/\r\n|\r|\n/', trim($value)));
+						$rows = count($valueWithSpaces);
+						$rows = max($rows, 2); // always min 2 rows for textarea
+					}
+					else {
+						$rows = $setting['attrs']['rows'];
 					}
 
-					$enabled = $setting['enabled'] ?? true;
+					$cols = $setting['attrs']['cols'] ?? 50;
 
-					echo '<textarea class="form-control" rows="' . $rows . '" name="settings[' . $key . ']" id="' . $key . '" ' . ($enabled ? '' : 'disabled') . '>' . escapeHtml($value) . '</textarea>';
+					echo '<textarea class="form-control" rows="' . $rows . '" cols="' . $cols . '" name="settings[' . $key . ']" id="' . $key . '" ' . $extraAttributes . '>' . escapeHtml($value) . '</textarea>';
 				}
 
 				elseif ($setting['type'] === 'options' || $setting['type'] === 'select') {
@@ -295,9 +370,7 @@ class Settings implements \ArrayAccess
 						}
 					}
 
-					$enabled = $setting['enabled'] ?? true;
-
-					echo '<select class="form-control" name="settings[' . $key . ']" id="' . $key . '" ' . ($enabled ? '' : 'disabled') . '>';
+					echo '<select class="form-control" name="settings[' . $key . ']" id="' . $key . '" ' . $extraAttributes . '>';
 					foreach ($setting['options'] as $value => $option) {
 						$compareTo = ($settingsDb[$key] ?? ($setting['default'] ?? ''));
 						if($value === 'true') {
@@ -330,35 +403,6 @@ class Settings implements \ArrayAccess
 				else {
 					if (in_array($setting['type'], ['float', 'double', 'integer', 'int'])) {
 						$setting['type'] = 'number';
-					}
-
-					$extraAttributes = '';
-
-					foreach ([
-						'min',
-						'max',
-						'step',
-						'size',
-						'minlength',
-						'maxlength',
-						'placeholder',
-						'pattern',
-						'autocomplete'
-					] as $attr) {
-						$extraAttributes .= (isset($setting[$attr]) ? ' ' . $attr . '="' . $setting[$attr] . '"' : '');
-					}
-
-					foreach ([
-						'readonly',
-						'disabled',
-						'required',
-						'autofocus'
-					] as $attr) {
-						if (isset($setting[$attr]) && !is_bool($setting[$attr])) {
-							throw new \RuntimeException("Setting $plugin.$key: attribute '$attr' must be boolean");
-						}
-
-						$extraAttributes .= (isset($setting[$attr]) && $setting[$attr] ? ' ' . $attr : '');
 					}
 
 					if ($setting['type'] === 'password') {

--- a/system/src/Settings.php
+++ b/system/src/Settings.php
@@ -210,21 +210,22 @@ class Settings implements \ArrayAccess
 						<td>
 							<?php
 				}
+
 				if (isset($setting['hidden']) && $setting['hidden']) {
 					$value = '';
 					if ($setting['type'] === 'boolean') {
 						$value = (getBoolean($setting['default']) ? 'true' : 'false');
 					}
-					else if (in_array($setting['type'], ['text', 'number', 'float', 'double', 'email', 'password', 'textarea'])) {
-						$value = $setting['default'];
-					}
 					else if ($setting['type'] === 'options') {
 						$value = $setting['options'][$setting['default']];
+					}
+					else {
+						$value = $setting['default'];
 					}
 
 					echo '<input type="hidden" name="settings[' . $key . ']" value="' . $value . '" id="' . $key . '"';
 				}
-				else if ($setting['type'] === 'boolean') {
+				elseif ($setting['type'] === 'boolean' || $setting['type'] === 'bool') {
 					if(isset($settingsDb[$key])) {
 						$value = getBoolean($settingsDb[$key]);
 					}
@@ -236,34 +237,7 @@ class Settings implements \ArrayAccess
 					$checkbox($key, false, $value, $setting['enabled'] ?? true);
 				}
 
-				else if (in_array($setting['type'], ['text', 'number', 'float', 'double', 'email', 'password', 'date', 'datetime-local', 'time'])) {
-					if (in_array($setting['type'], ['float', 'double'])) {
-						$setting['type'] = 'number';
-					}
-
-					if ($setting['type'] === 'number') {
-						$min = (isset($setting['min']) ? ' min="' . $setting['min'] . '"' : '');
-						$max = (isset($setting['max']) ? ' max="' . $setting['max'] . '"' : '');
-						$step = (isset($setting['step']) ? ' step="' . $setting['step'] . '"' : '');
-					}
-					else {
-						$min = $max = $step = '';
-					}
-
-					if ($setting['type'] === 'password') {
-						echo '<div class="input-group" id="show-hide-' . $key . '">';
-					}
-
-					$enabled = $setting['enabled'] ?? true;
-
-					echo '<input class="form-control" type="' . $setting['type'] . '" name="settings[' . $key . ']" value="' . escapeHtml($settingsDb[$key] ?? ($setting['default'] ?? '')) . '" id="' . $key . '"' . $min . $max . $step . ' ' . ($enabled ? '' : 'disabled') . '/>';
-
-					if ($setting['type'] === 'password') {
-						echo '<div class="input-group-append input-group-text"><a href=""><i class="fas fa-eye-slash" ></i></a></div></div>';
-					}
-				}
-
-				else if($setting['type'] === 'textarea') {
+				elseif ($setting['type'] === 'textarea') {
 					if (isset($settingsDb[$key]) && is_array($settingsDb[$key])) {
 						$settingsDb[$key] = implode(',', $settingsDb[$key]);
 					}
@@ -280,7 +254,7 @@ class Settings implements \ArrayAccess
 					echo '<textarea class="form-control" rows="' . $rows . '" name="settings[' . $key . ']" id="' . $key . '" ' . ($enabled ? '' : 'disabled') . '>' . escapeHtml($value) . '</textarea>';
 				}
 
-				else if ($setting['type'] === 'options') {
+				elseif ($setting['type'] === 'options' || $setting['type'] === 'select') {
 					if ($setting['options'] === '$templates') {
 						$templates = [];
 						foreach (get_templates() as $value) {
@@ -303,7 +277,7 @@ class Settings implements \ArrayAccess
 
 						$setting['options'] = $clients;
 					}
-					else if ($setting['options'] == '$timezones') {
+					else if ($setting['options'] === '$timezones') {
 						$timezones = [];
 						foreach (\DateTimeZone::listIdentifiers() as $value) {
 							$timezones[$value] = $value;
@@ -341,6 +315,63 @@ class Settings implements \ArrayAccess
 					echo '</select>';
 				}
 
+				elseif ($setting['type'] === 'custom') {
+					if (!isset($setting['custom']) || !is_callable($setting['custom'])) {
+						throw new \RuntimeException("Setting $plugin.$key: attribute 'custom' must be callable");
+					}
+
+					if (!isset($settingsDb[$key])) {
+						$settingsDb[$key] = ($setting['default'] ?? '');
+					}
+
+					echo $setting['custom']($key, $settingsDb[$key]);
+				}
+
+				else {
+					if (in_array($setting['type'], ['float', 'double', 'integer', 'int'])) {
+						$setting['type'] = 'number';
+					}
+
+					$extraAttributes = '';
+
+					foreach ([
+						'min',
+						'max',
+						'step',
+						'size',
+						'minlength',
+						'maxlength',
+						'placeholder',
+						'pattern',
+						'autocomplete'
+					] as $attr) {
+						$extraAttributes .= (isset($setting[$attr]) ? ' ' . $attr . '="' . $setting[$attr] . '"' : '');
+					}
+
+					foreach ([
+						'readonly',
+						'disabled',
+						'required',
+						'autofocus'
+					] as $attr) {
+						if (isset($setting[$attr]) && !is_bool($setting[$attr])) {
+							throw new \RuntimeException("Setting $plugin.$key: attribute '$attr' must be boolean");
+						}
+
+						$extraAttributes .= (isset($setting[$attr]) && $setting[$attr] ? ' ' . $attr : '');
+					}
+
+					if ($setting['type'] === 'password') {
+						echo '<div class="input-group" id="show-hide-' . $key . '">';
+					}
+
+					echo '<input class="form-control" type="' . $setting['type'] . '" name="settings[' . $key . ']" value="' . escapeHtml($settingsDb[$key] ?? ($setting['default'] ?? '')) . '" id="' . $key . '"' . $extraAttributes . '/>';
+
+					if ($setting['type'] === 'password') {
+						echo '<div class="input-group-append input-group-text"><a href=""><i class="fas fa-eye-slash" ></i></a></div></div>';
+					}
+				}
+
 				if (!isset($setting['hidden']) || !$setting['hidden']) {
 				?>
 						</td>
@@ -353,13 +384,13 @@ class Settings implements \ArrayAccess
 								if ($setting['type'] === 'boolean') {
 									echo ($setting['default'] ? 'Yes' : 'No');
 								}
-								else if (in_array($setting['type'], ['text', 'number', 'float', 'double', 'email', 'password', 'textarea'])) {
-									echo $setting['default'];
-								}
-								else if ($setting['type'] === 'options') {
+								elseif ($setting['type'] === 'options') {
 									if (is_int($setting['default']) || !empty($setting['default'])) {
 										echo $setting['options'][$setting['default']];
 									}
+								}
+								else {
+									echo $setting['default'] ?? '';
 								}
 								?></div>
 						</td>
@@ -495,16 +526,19 @@ class Settings implements \ArrayAccess
 		if(isset($ret['type'])) {
 			switch($ret['type']) {
 				case 'boolean':
+				case 'bool':
 					$ret['value'] = getBoolean($ret['value']);
 					break;
 
 				case 'number':
+				case 'integer':
+				case 'int':
 					$ret['value'] = (int)$ret['value'];
 					break;
 
 				case 'double':
 				case 'float':
-					$ret['value'] = (double)($ret['value']);
+					$ret['value'] = (float)($ret['value']);
 					break;
 
 				default:

--- a/system/templates/admin.settings.html.twig
+++ b/system/templates/admin.settings.html.twig
@@ -31,6 +31,10 @@
 	.setting-default {
 		white-space: pre-wrap;
 	}
+
+	textarea {
+		width: auto !important;
+	}
 </style>
 <script>
 	function doShowHide(el, show)


### PR DESCRIPTION
All possible HTML input types are available:
* color
* range
* month/week

etc.

Also additional attributes are now possible:
* minlength/maxlength
* placeholder/pattern/autocomplete

And boolean attributes:
* readonly
* disabled
* required
* autofocus

Also custom settings are possible.

Example of custom setting:
```php
'fav_language' => [
	'name' => 'Fav language',
	'desc' => 'Select your favorite programming language.',
	'type' => 'custom',
	'custom' => function ($key, $value) {
		echo '
			<input type="radio" id="html" name="settings[' . $key . ']" value="HTML" '. ($value === 'HTML' ? 'checked' : '') . '>
			<label for="html">HTML</label><br>
			<input type="radio" id="css" name="settings[' . $key . ']" value="CSS" '. ($value === 'CSS' ? 'checked' : '') . '>
			<label for="css">CSS</label><br>
			<input type="radio" id="javascript" name="settings[' . $key . ']" value="JavaScript" '. ($value === 'JavaScript' ? 'checked' : '') . '>
			<label for="javascript">JavaScript</label>';
	},
],
```

TODO:
* [x] Rewrite to support any attribute, in the 'attrs' array
* [x] textarea, boolean attr support
* [x] textarea rows, cols